### PR TITLE
#2 Fix AWS V4 signature regexp

### DIFF
--- a/auth/center.go
+++ b/auth/center.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var authorizationFieldRegexp = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=(?P<access_key_id>[^/]+)/(?P<date>[^/]+)/(?P<region>[^/]*)/(?P<service>[^/]+)/aws4_request, SignedHeaders=(?P<signed_header_fields>.*), Signature=(?P<v4_signature>.*)`)
+var authorizationFieldRegexp = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=(?P<access_key_id>[^/]+)/(?P<date>[^/]+)/(?P<region>[^/]*)/(?P<service>[^/]+)/aws4_request,\s*SignedHeaders=(?P<signed_header_fields>.+),\s*Signature=(?P<v4_signature>.+)`)
 
 const emptyStringSHA256 = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 


### PR DESCRIPTION
We now respect possible spaces in parts of Authorization header field whoses presence causes problems for some client apps (such as aws cli).

Signed-off-by: Pavel Korotkov <pkorotkov@gmail.com>