### PR TITLE
Prepare go modules to build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020152448-c8f46f7d9762
-	github.com/nspcc-dev/neofs-authmate v0.0.0
+	github.com/nspcc-dev/neofs-api-go v0.0.0-20201029071528-352e99d9b91a
+	github.com/nspcc-dev/neofs-authmate v0.0.0-20201024131449-35d634118c0d
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.9.1
@@ -33,10 +33,4 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect
-)
-
-// temporary
-replace (
-	github.com/nspcc-dev/neofs-api-go => ../neofs-api
-	github.com/nspcc-dev/neofs-authmate => ../neofs-authmate
 )

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,11 @@ github.com/nspcc-dev/hrw v1.0.9/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkP
 github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:pPYwPZ2ks+uMnlRLUyXOpLieaDQSEaf4NM3zHVbRjmg=
 github.com/nspcc-dev/neo-go v0.91.0 h1:KKOPMKs0fm8JIau1SuwxiLdrZ+1kDPBiVRlWwzfebWE=
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
+github.com/nspcc-dev/neofs-api-go v0.0.0-20201022161545-ad0b01e892dd/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v0.0.0-20201029071528-352e99d9b91a h1:A/8D9A9Fbp4tw1xGgfZB0vtPKEQ/LYq0l7DFuM4KeS4=
+github.com/nspcc-dev/neofs-api-go v0.0.0-20201029071528-352e99d9b91a/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-authmate v0.0.0-20201024131449-35d634118c0d h1:X/hrFKVSu42PPmRiaITk9okspO9oSNmg71TZ6YIAQUw=
+github.com/nspcc-dev/neofs-authmate v0.0.0-20201024131449-35d634118c0d/go.mod h1:GmnOjaC1aIb2umz3q1dvU0Y5kk+FFhEsps0j6/QJf30=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
Need `GOPRIVATE=github.com/nspcc-dev` while repos in private:
- github.com/nspcc-dev/neofs-api-go
- github.com/nspcc-dev/neofs-authmate

Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>