### PR TITLE
[#53] *: Remove external pkg/errors dependency

### DIFF
--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -2,6 +2,7 @@ package layer
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/url"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/cmd/authmate/main.go
+++ b/cmd/authmate/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nspcc-dev/cdn-sdk/pool"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	"github.com/nspcc-dev/neofs-s3-gw/authmate"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -379,7 +378,7 @@ func createSDKClient(ctx context.Context, log *zap.Logger, neofsCreds neofs.Cred
 		pool.WithConnectTimeout(poolConnectTimeout),
 		pool.WithRequestTimeout(poolRequestTimeout))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create connection pool")
+		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
 
 	log.Debug("prepare sdk client")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/nspcc-dev/cdn-sdk v0.3.4
 	github.com/nspcc-dev/neofs-api-go v1.23.0
 	github.com/nspcc-dev/neofs-node v1.22.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1


### PR DESCRIPTION
Replaced functions from pkg/errors by functions from errors, fixed not fully correct comment

Note that in the old version of New (eg api/auth/center.go:68) we returned a message and a stack trace, now we return only a message. I couldn't find how to return also a stack trace using only errors package.