### PR TITLE
[#57] Fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ RUN set -x \
 
 COPY . /src
 
+ARG REPO=github.com/nspcc-dev/neofs-s3-gw
 ARG VERSION=dev
 
-RUN make
+RUN set -x && make -o dep # run make without dep dependency
 
 # Executable image
 FROM scratch
@@ -18,6 +19,7 @@ FROM scratch
 WORKDIR /
 
 COPY --from=builder /src/bin/neofs-s3-gw /bin/neofs-s3-gw
+COPY --from=builder /src/bin/neofs-authmate /bin/neofs-authmate
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/bin/neofs-s3-gw"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ CMDS = $(addprefix neofs-, $(notdir $(wildcard cmd/*)))
 BINS = $(addprefix $(BINDIR)/, $(CMDS))
 
 # Variables for docker
-HUB_IMAGE ?= "nspccdev/$(BIN_NAME)"
+REPO_BASENAME = $(shell basename `go list -m`)
+HUB_IMAGE ?= "nspccdev/$(REPO_BASENAME)"
 HUB_TAG ?= "$(shell echo ${VERSION} | sed 's/^v//')"
 
 .PHONY: help all dep clean format test cover lint docker/lint image-push image dirty-image
@@ -55,7 +56,7 @@ format:
 	@goimports -w ./
 
 # Build clean Docker image
-image:
+image: dep
 	@echo "⇒ Build NeoFS S3 Gateway docker image "
 	@docker build \
 		--build-arg REPO=$(REPO) \


### PR DESCRIPTION
Closes #57 

There was  an error in building of docker image because docker was executing a target 'make' with a target dep inside of 'docker build' .
Added downloading of dependencies to before docker build and made 'RUN make' without dep target.