### PR TITLE
[#64]  Fix access key id

### DIFF
--- a/api/auth/center.go
+++ b/api/auth/center.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var authorizationFieldRegexp = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=(?P<access_key_id_cid>[^/]+)/(?P<access_key_id_oid>[^/]+)/(?P<date>[^/]+)/(?P<region>[^/]*)/(?P<service>[^/]+)/aws4_request,\s*SignedHeaders=(?P<signed_header_fields>.+),\s*Signature=(?P<v4_signature>.+)`)
+var authorizationFieldRegexp = regexp.MustCompile(`AWS4-HMAC-SHA256 Credential=(?P<access_key_id_cid>[^/]+)_(?P<access_key_id_oid>[^/]+)/(?P<date>[^/]+)/(?P<region>[^/]*)/(?P<service>[^/]+)/aws4_request,\s*SignedHeaders=(?P<signed_header_fields>.+),\s*Signature=(?P<v4_signature>.+)`)
 
 type (
 	// Center is a user authentication interface.
@@ -88,10 +88,11 @@ func (c *center) Authenticate(r *http.Request) (*token.BearerToken, error) {
 		return nil, fmt.Errorf("failed to parse x-amz-date header field: %w", err)
 	}
 
-	accessKeyID := fmt.Sprintf("%s/%s", sms1["access_key_id_cid"], sms1["access_key_id_oid"])
+	accessKeyID := fmt.Sprintf("%s_%s", sms1["access_key_id_cid"], sms1["access_key_id_oid"])
+	accessKeyAddress := fmt.Sprintf("%s/%s", sms1["access_key_id_cid"], sms1["access_key_id_oid"])
 
 	address := object.NewAddress()
-	if err = address.Parse(accessKeyID); err != nil {
+	if err = address.Parse(accessKeyAddress); err != nil {
 		return nil, fmt.Errorf("could not parse AccessBox address: %s : %w", accessKeyID, err)
 	}
 

--- a/authmate/authmate.go
+++ b/authmate/authmate.go
@@ -162,8 +162,10 @@ func (a *Agent) IssueSecret(ctx context.Context, w io.Writer, options *IssueSecr
 		return fmt.Errorf("failed to get bearer token secret key: %w", err)
 	}
 
+	accessKeyID := address.ContainerID().String() + "_" + address.ObjectID().String()
+
 	ir := &issuingResult{
-		AccessKeyID:     address.String(),
+		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secret,
 		OwnerPrivateKey: options.OwnerPrivateKey.String(),
 	}

--- a/cmd/authmate/main.go
+++ b/cmd/authmate/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,7 +38,7 @@ var (
 	peerAddressFlag       string
 	eaclRulesFlag         string
 	gatePrivateKeyFlag    string
-	secretAddressFlag     string
+	accessKeyIDFlag       string
 	ownerPrivateKeyFlag   string
 	containerIDFlag       string
 	containerFriendlyName string
@@ -311,10 +312,10 @@ func obtainSecret() *cli.Command {
 				Destination: &gatePrivateKeyFlag,
 			},
 			&cli.StringFlag{
-				Name:        "secret-address",
-				Usage:       "address of a secret (i.e. access key id for s3)",
+				Name:        "access-key-id",
+				Usage:       "access key id for s3",
 				Required:    true,
-				Destination: &secretAddressFlag,
+				Destination: &accessKeyIDFlag,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -342,8 +343,10 @@ func obtainSecret() *cli.Command {
 				return cli.Exit(fmt.Sprintf("failed to create owner's private key: %s", err), 4)
 			}
 
+			secretAddress := strings.Replace(accessKeyIDFlag, "_", "/", 1)
+
 			obtainSecretOptions := &authmate.ObtainSecretOptions{
-				SecretAddress:  secretAddressFlag,
+				SecretAddress:  secretAddress,
 				GatePrivateKey: gateCreds.PrivateKey(),
 			}
 


### PR DESCRIPTION
Closes #64 

Replaced forbidden symbol '/' in access key id by '_'.
SecretKeyAddress and SecretKeyID are different things now.
Renamed param of authmate from secretAddressFlag to accessKeyIDFlag,
that is more correct, imo.

Finally, aws cli can connect to the gateway.