### PR TITLE
Fix util tests

### DIFF
--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -127,6 +127,7 @@ func objectInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, delimiter 
 		index := strings.Index(tail, delimiter)
 		if index >= 0 {
 			isDir = true
+			mimeType = ""
 			filename = prefix + tail[:index+1]
 			userHeaders = nil
 		} else {

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -28,12 +28,16 @@ func newTestObject(oid *object.ID, bkt *BucketInfo, name string) *object.Object 
 	created.SetKey(object.AttributeTimestamp)
 	created.SetValue(strconv.FormatInt(defaultTestCreated.Unix(), 10))
 
+	contentType := object.NewAttribute()
+	contentType.SetKey(object.AttributeContentType)
+	contentType.SetValue(defaultTestContentType)
+
 	raw := object.NewRaw()
 	raw.SetID(oid)
 	raw.SetOwnerID(bkt.Owner)
 	raw.SetContainerID(bkt.CID)
 	raw.SetPayload(defaultTestPayload)
-	raw.SetAttributes(filename, created)
+	raw.SetAttributes(filename, created, contentType)
 	raw.SetPayloadSize(uint64(defaultTestPayloadLength))
 
 	return raw.Object()


### PR DESCRIPTION
Closes #145 
Tests didn't pass because of an expected object had a ContentType "text/plain; charset=utf-8" or "" depending on is the object in "a directory" or not. An actual object always had ContentType "". 

Now the actual object's ContentType depends on isDir value the same as in the expected objects.