### PR TITLE
[#198] Fix object metadata

### DIFF
--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -73,7 +73,7 @@ func writeHeaders(h http.Header, info *layer.ObjectInfo) {
 	h.Set(api.ETag, info.HashSum)
 
 	for key, val := range info.Headers {
-		h.Set(api.MetadataPrefix+key, val)
+		h[api.MetadataPrefix+key] = []string{val}
 	}
 }
 

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -59,7 +59,7 @@ func parseMetadata(r *http.Request) map[string]string {
 	res := make(map[string]string)
 	for k, v := range r.Header {
 		if strings.HasPrefix(k, api.MetadataPrefix) {
-			key := strings.TrimPrefix(k, api.MetadataPrefix)
+			key := strings.ToLower(strings.TrimPrefix(k, api.MetadataPrefix))
 			res[key] = v[0]
 		}
 	}


### PR DESCRIPTION
The following test now pass: 
* s3tests_boto3.functional.test_s3:test_object_set_get_metadata_none_to_good

closes #198 

Signed-off-by: Denis Kirillov <denis@nspcc.ru>