### PR TITLE
[#191] Improve copy object compatibility

### DIFF
--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -37,6 +37,9 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 	)
 
 	metadata := parseMetadata(r)
+	if contentType := r.Header.Get(api.ContentType); len(contentType) > 0 {
+		metadata[api.ContentType] = contentType
+	}
 
 	params := &layer.PutObjectParams{
 		Bucket: reqInfo.BucketName,

--- a/api/headers.go
+++ b/api/headers.go
@@ -2,7 +2,8 @@ package api
 
 // Standard S3 HTTP request/response constants.
 const (
-	MetadataPrefix = "X-Amz-Meta-"
+	MetadataPrefix       = "X-Amz-Meta-"
+	AmzMetadataDirective = "X-Amz-Metadata-Directive"
 
 	LastModified       = "Last-Modified"
 	Date               = "Date"


### PR DESCRIPTION
The following tests now pass:
* s3tests_boto3.functional.test_s3:test_object_copy_verify_contenttype 
* s3tests_boto3.functional.test_s3:test_object_copy_to_itself 
* s3tests_boto3.functional.test_s3:test_object_copy_retaining_metadata 
* s3tests_boto3.functional.test_s3:test_object_copy_replacing_metadata 
* s3tests_boto3.functional.test_s3:test_object_copy_bucket_not_found 
* s3tests_boto3.functional.test_s3:test_object_copy_key_not_found

closes #191 

Signed-off-by: Denis Kirillov <denis@nspcc.ru>