### PR TITLE
[#122] Add enabling versioning

### DIFF
--- a/api/cache/bucket.go
+++ b/api/cache/bucket.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/bluele/gcache"
+	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+)
+
+type (
+	// BucketCache provides interface for lru cache for objects.
+	BucketCache interface {
+		Get(key string) *BucketInfo
+		Put(bkt *BucketInfo) error
+		Delete(key string) bool
+	}
+
+	// BucketInfo stores basic bucket data.
+	BucketInfo struct {
+		Name    string
+		CID     *cid.ID
+		Owner   *owner.ID
+		Created time.Time
+	}
+
+	// GetBucketCache contains cache with objects and lifetime of cache entries.
+	GetBucketCache struct {
+		cache    gcache.Cache
+		lifetime time.Duration
+	}
+)
+
+// NewBucketCache creates an object of BucketCache.
+func NewBucketCache(cacheSize int, lifetime time.Duration) *GetBucketCache {
+	gc := gcache.New(cacheSize).LRU().Build()
+
+	return &GetBucketCache{cache: gc, lifetime: lifetime}
+}
+
+// Get returns cached object.
+func (o *GetBucketCache) Get(key string) *BucketInfo {
+	entry, err := o.cache.Get(key)
+	if err != nil {
+		return nil
+	}
+
+	result, ok := entry.(*BucketInfo)
+	if !ok {
+		return nil
+	}
+
+	return result
+}
+
+// Put puts an object to cache.
+func (o *GetBucketCache) Put(bkt *BucketInfo) error {
+	return o.cache.SetWithExpire(bkt.Name, bkt, o.lifetime)
+}
+
+// Delete deletes an object from cache.
+func (o *GetBucketCache) Delete(key string) bool {
+	return o.cache.Remove(key)
+}

--- a/api/cache/buckets.go
+++ b/api/cache/buckets.go
@@ -18,10 +18,11 @@ type (
 
 	// BucketInfo stores basic bucket data.
 	BucketInfo struct {
-		Name    string
-		CID     *cid.ID
-		Owner   *owner.ID
-		Created time.Time
+		Name     string
+		CID      *cid.ID
+		Owner    *owner.ID
+		Created  time.Time
+		BasicACL uint32
 	}
 
 	// GetBucketCache contains cache with objects and lifetime of cache entries.
@@ -61,4 +62,16 @@ func (o *GetBucketCache) Put(bkt *BucketInfo) error {
 // Delete deletes an object from cache.
 func (o *GetBucketCache) Delete(key string) bool {
 	return o.cache.Remove(key)
+}
+
+const bktVersionSettingsObject = ".s3-versioning-settings"
+
+// SettingsObjectName is system name for bucket settings file.
+func (b *BucketInfo) SettingsObjectName() string {
+	return bktVersionSettingsObject
+}
+
+// SettingsObjectKey is key to use in SystemCache.
+func (b *BucketInfo) SettingsObjectKey() string {
+	return b.Name + bktVersionSettingsObject
 }

--- a/api/cache/head_cache.go
+++ b/api/cache/head_cache.go
@@ -1,0 +1,55 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+)
+
+// HeadObjectsCache provides interface for lru cache for objects.
+type HeadObjectsCache interface {
+	Get(key string) *object.Address
+	Put(key string, address *object.Address) error
+	Delete(key string) bool
+}
+
+type (
+	// HeadObjectCache contains cache with objects and lifetime of cache entries.
+	HeadObjectCache struct {
+		cache    gcache.Cache
+		lifetime time.Duration
+	}
+)
+
+// NewHeadObject creates an object of ObjectHeadersCache.
+func NewHeadObject(cacheSize int, lifetime time.Duration) *HeadObjectCache {
+	gc := gcache.New(cacheSize).LRU().Build()
+
+	return &HeadObjectCache{cache: gc, lifetime: lifetime}
+}
+
+// Get returns cached object.
+func (o *HeadObjectCache) Get(key string) *object.Address {
+	entry, err := o.cache.Get(key)
+	if err != nil {
+		return nil
+	}
+
+	result, ok := entry.(*object.Address)
+	if !ok {
+		return nil
+	}
+
+	return result
+}
+
+// Put puts an object to cache.
+func (o *HeadObjectCache) Put(key string, address *object.Address) error {
+	return o.cache.SetWithExpire(key, address, o.lifetime)
+}
+
+// Delete deletes an object from cache.
+func (o *HeadObjectCache) Delete(key string) bool {
+	return o.cache.Remove(key)
+}

--- a/api/cache/names.go
+++ b/api/cache/names.go
@@ -7,30 +7,32 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 )
 
-// HeadObjectsCache provides interface for lru cache for objects.
-type HeadObjectsCache interface {
+// ObjectsNameCache provides interface for lru cache for objects.
+// This cache contains mapping nice name to object addresses.
+// Key is bucketName+objectName.
+type ObjectsNameCache interface {
 	Get(key string) *object.Address
 	Put(key string, address *object.Address) error
 	Delete(key string) bool
 }
 
 type (
-	// HeadObjectCache contains cache with objects and lifetime of cache entries.
-	HeadObjectCache struct {
+	// NameCache contains cache with objects and lifetime of cache entries.
+	NameCache struct {
 		cache    gcache.Cache
 		lifetime time.Duration
 	}
 )
 
-// NewHeadObject creates an object of ObjectHeadersCache.
-func NewHeadObject(cacheSize int, lifetime time.Duration) *HeadObjectCache {
+// NewObjectsNameCache creates an object of ObjectsNameCache.
+func NewObjectsNameCache(cacheSize int, lifetime time.Duration) *NameCache {
 	gc := gcache.New(cacheSize).LRU().Build()
 
-	return &HeadObjectCache{cache: gc, lifetime: lifetime}
+	return &NameCache{cache: gc, lifetime: lifetime}
 }
 
 // Get returns cached object.
-func (o *HeadObjectCache) Get(key string) *object.Address {
+func (o *NameCache) Get(key string) *object.Address {
 	entry, err := o.cache.Get(key)
 	if err != nil {
 		return nil
@@ -45,11 +47,11 @@ func (o *HeadObjectCache) Get(key string) *object.Address {
 }
 
 // Put puts an object to cache.
-func (o *HeadObjectCache) Put(key string, address *object.Address) error {
+func (o *NameCache) Put(key string, address *object.Address) error {
 	return o.cache.SetWithExpire(key, address, o.lifetime)
 }
 
 // Delete deletes an object from cache.
-func (o *HeadObjectCache) Delete(key string) bool {
+func (o *NameCache) Delete(key string) bool {
 	return o.cache.Remove(key)
 }

--- a/api/cache/object_cache.go
+++ b/api/cache/object_cache.go
@@ -10,7 +10,7 @@ import (
 // ObjectsCache provides interface for lru cache for objects.
 type ObjectsCache interface {
 	Get(address *object.Address) *object.Object
-	Put(address *object.Address, obj object.Object) error
+	Put(obj object.Object) error
 	Delete(address *object.Address) bool
 }
 
@@ -52,8 +52,8 @@ func (o *ObjectHeadersCache) Get(address *object.Address) *object.Object {
 }
 
 // Put puts an object to cache.
-func (o *ObjectHeadersCache) Put(address *object.Address, obj object.Object) error {
-	return o.cache.SetWithExpire(address.String(), obj, o.lifetime)
+func (o *ObjectHeadersCache) Put(obj object.Object) error {
+	return o.cache.SetWithExpire(obj.ContainerID().String()+"/"+obj.ID().String(), obj, o.lifetime)
 }
 
 // Delete deletes an object from cache.

--- a/api/cache/object_cache_test.go
+++ b/api/cache/object_cache_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+
 	objecttest "github.com/nspcc-dev/neofs-api-go/pkg/object/test"
 	"github.com/stretchr/testify/require"
 )
@@ -14,23 +16,23 @@ const (
 )
 
 func TestCache(t *testing.T) {
-	var (
-		address = objecttest.Address()
-		object  = objecttest.Object()
-	)
+	obj := objecttest.Object()
+	address := object.NewAddress()
+	address.SetContainerID(obj.ContainerID())
+	address.SetObjectID(obj.ID())
 
 	t.Run("check get", func(t *testing.T) {
 		cache := New(cachesize, lifetime)
-		err := cache.Put(address, *object)
+		err := cache.Put(*obj)
 		require.NoError(t, err)
 
 		actual := cache.Get(address)
-		require.Equal(t, object, actual)
+		require.Equal(t, obj, actual)
 	})
 
 	t.Run("check delete", func(t *testing.T) {
 		cache := New(cachesize, lifetime)
-		err := cache.Put(address, *object)
+		err := cache.Put(*obj)
 		require.NoError(t, err)
 
 		cache.Delete(address)

--- a/api/cache/object_cache_test.go
+++ b/api/cache/object_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
-
 	objecttest "github.com/nspcc-dev/neofs-api-go/pkg/object/test"
 	"github.com/stretchr/testify/require"
 )

--- a/api/cache/system.go
+++ b/api/cache/system.go
@@ -3,35 +3,36 @@ package cache
 import (
 	"time"
 
-	"github.com/nspcc-dev/neofs-api-go/pkg/object"
-
 	"github.com/bluele/gcache"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 )
 
 type (
 	// SystemCache provides interface for lru cache for objects.
+	// This cache contains "system" objects (bucket versioning settings, tagging object etc.).
+	// Key is bucketName+systemFileName.
 	SystemCache interface {
 		Get(key string) *object.Object
 		Put(key string, obj *object.Object) error
 		Delete(key string) bool
 	}
 
-	// systemCache contains cache with objects and lifetime of cache entries.
-	systemCache struct {
+	// SysCache contains cache with objects and lifetime of cache entries.
+	SysCache struct {
 		cache    gcache.Cache
 		lifetime time.Duration
 	}
 )
 
 // NewSystemCache creates an object of SystemCache.
-func NewSystemCache(cacheSize int, lifetime time.Duration) SystemCache {
+func NewSystemCache(cacheSize int, lifetime time.Duration) *SysCache {
 	gc := gcache.New(cacheSize).LRU().Build()
 
-	return &systemCache{cache: gc, lifetime: lifetime}
+	return &SysCache{cache: gc, lifetime: lifetime}
 }
 
 // Get returns cached object.
-func (o *systemCache) Get(key string) *object.Object {
+func (o *SysCache) Get(key string) *object.Object {
 	entry, err := o.cache.Get(key)
 	if err != nil {
 		return nil
@@ -46,11 +47,11 @@ func (o *systemCache) Get(key string) *object.Object {
 }
 
 // Put puts an object to cache.
-func (o *systemCache) Put(key string, obj *object.Object) error {
+func (o *SysCache) Put(key string, obj *object.Object) error {
 	return o.cache.SetWithExpire(key, obj, o.lifetime)
 }
 
 // Delete deletes an object from cache.
-func (o *systemCache) Delete(key string) bool {
+func (o *SysCache) Delete(key string) bool {
 	return o.cache.Remove(key)
 }

--- a/api/cache/system.go
+++ b/api/cache/system.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+
+	"github.com/bluele/gcache"
+)
+
+type (
+	// SystemCache provides interface for lru cache for objects.
+	SystemCache interface {
+		Get(key string) *object.Object
+		Put(key string, obj *object.Object) error
+		Delete(key string) bool
+	}
+
+	// systemCache contains cache with objects and lifetime of cache entries.
+	systemCache struct {
+		cache    gcache.Cache
+		lifetime time.Duration
+	}
+)
+
+// NewSystemCache creates an object of SystemCache.
+func NewSystemCache(cacheSize int, lifetime time.Duration) SystemCache {
+	gc := gcache.New(cacheSize).LRU().Build()
+
+	return &systemCache{cache: gc, lifetime: lifetime}
+}
+
+// Get returns cached object.
+func (o *systemCache) Get(key string) *object.Object {
+	entry, err := o.cache.Get(key)
+	if err != nil {
+		return nil
+	}
+
+	result, ok := entry.(*object.Object)
+	if !ok {
+		return nil
+	}
+
+	return result
+}
+
+// Put puts an object to cache.
+func (o *systemCache) Put(key string, obj *object.Object) error {
+	return o.cache.SetWithExpire(key, obj, o.lifetime)
+}
+
+// Delete deletes an object from cache.
+func (o *systemCache) Delete(key string) bool {
+	return o.cache.Remove(key)
+}

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -66,6 +66,7 @@ const (
 	ErrNoSuchKey
 	ErrNoSuchUpload
 	ErrNoSuchVersion
+	ErrInvalidVersion
 	ErrNotImplemented
 	ErrPreconditionFailed
 	ErrNotModified
@@ -528,6 +529,12 @@ var errorCodes = errorCodeMap{
 		Code:           "NoSuchVersion",
 		Description:    "Indicates that the version ID specified in the request does not match an existing version.",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrInvalidVersion: {
+		ErrCode:        ErrInvalidVersion,
+		Code:           "InvalidArgument",
+		Description:    "Invalid version id specified",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrNotImplemented: {
 		ErrCode:        ErrNotImplemented,

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -1924,26 +1924,18 @@ func GetAPIError(code ErrorCode) Error {
 	return errorCodes.toAPIErr(ErrInternalError)
 }
 
-// GenericError - generic object layer error.
-type GenericError struct {
-	Bucket string
-	Object string
+// ObjectError - error that linked to specific object.
+type ObjectError struct {
+	Err     error
+	Object  string
+	Version string
 }
 
-// ObjectAlreadyExists object already exists.
-// This type should be removed when s3-gw will support versioning.
-type ObjectAlreadyExists GenericError
-
-func (e ObjectAlreadyExists) Error() string {
-	return "Object: " + e.Bucket + "#" + e.Object + " already exists"
+func (e ObjectError) Error() string {
+	return fmt.Sprintf("%s (%s:%s)", e.Err, e.Object, e.Version)
 }
 
-// DeleteError - returns when cant remove object.
-type DeleteError struct {
-	Err    error
-	Object string
-}
-
-func (e DeleteError) Error() string {
-	return fmt.Sprintf("%s (%s)", e.Err, e.Object)
+// ObjectVersion get "object:version" string.
+func (e ObjectError) ObjectVersion() string {
+	return e.Object + ":" + e.Version
 }

--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -32,10 +32,11 @@ func path2BucketObject(path string) (bucket, prefix string) {
 func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	var (
 		err      error
-		inf      *layer.ObjectInfo
+		info     *layer.ObjectInfo
 		metadata map[string]string
 
-		reqInfo = api.GetReqInfo(r.Context())
+		reqInfo   = api.GetReqInfo(r.Context())
+		versionID string
 	)
 
 	src := r.Header.Get("X-Amz-Copy-Source")
@@ -45,14 +46,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	// of the version ID to null. If you have enabled versioning, Amazon S3 assigns a
 	// unique version ID value for the object.
 	if u, err := url.Parse(src); err == nil {
-		// Check if versionId query param was added, if yes then check if
-		// its non "null" value, we should error out since we do not support
-		// any versions other than "null".
-		if vid := u.Query().Get("versionId"); vid != "" && vid != "null" {
-			h.logAndSendError(w, "no such version", reqInfo, errors.GetAPIError(errors.ErrNoSuchVersion))
-			return
-		}
-
+		versionID = u.Query().Get(api.QueryVersionID)
 		src = u.Path
 	}
 
@@ -66,7 +60,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	p := &layer.HeadObjectParams{
 		Bucket:    srcBucket,
 		Object:    srcObject,
-		VersionID: reqInfo.URL.Query().Get("versionId"),
+		VersionID: versionID,
 	}
 
 	if args.MetadataDirective == replaceMetadataDirective {
@@ -85,46 +79,46 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if inf, err = h.obj.GetObjectInfo(r.Context(), p); err != nil {
+	if info, err = h.obj.GetObjectInfo(r.Context(), p); err != nil {
 		h.logAndSendError(w, "could not find object", reqInfo, err)
 		return
 	}
 
-	if err = checkPreconditions(inf, args.Conditional); err != nil {
+	if err = checkPreconditions(info, args.Conditional); err != nil {
 		h.logAndSendError(w, "precondition failed", reqInfo, errors.GetAPIError(errors.ErrPreconditionFailed))
 		return
 	}
 
 	if metadata == nil {
-		if len(inf.ContentType) > 0 {
-			inf.Headers[api.ContentType] = inf.ContentType
+		if len(info.ContentType) > 0 {
+			info.Headers[api.ContentType] = info.ContentType
 		}
-		metadata = inf.Headers
+		metadata = info.Headers
 	} else if contentType := r.Header.Get(api.ContentType); len(contentType) > 0 {
 		metadata[api.ContentType] = contentType
 	}
 
 	params := &layer.CopyObjectParams{
-		SrcObject: inf,
+		SrcObject: info,
 		DstBucket: reqInfo.BucketName,
 		DstObject: reqInfo.ObjectName,
-		SrcSize:   inf.Size,
+		SrcSize:   info.Size,
 		Header:    metadata,
 	}
 
 	additional := []zap.Field{zap.String("src_bucket_name", srcBucket), zap.String("src_object_name", srcObject)}
-	if inf, err = h.obj.CopyObject(r.Context(), params); err != nil {
+	if info, err = h.obj.CopyObject(r.Context(), params); err != nil {
 		h.logAndSendError(w, "couldn't copy object", reqInfo, err, additional...)
 		return
-	} else if err = api.EncodeToResponse(w, &CopyObjectResponse{LastModified: inf.Created.Format(time.RFC3339), ETag: inf.HashSum}); err != nil {
+	} else if err = api.EncodeToResponse(w, &CopyObjectResponse{LastModified: info.Created.Format(time.RFC3339), ETag: info.HashSum}); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err, additional...)
 		return
 	}
 
 	h.log.Info("object is copied",
-		zap.String("bucket", inf.Bucket),
-		zap.String("object", inf.Name),
-		zap.Stringer("object_id", inf.ID()))
+		zap.String("bucket", info.Bucket),
+		zap.String("object", info.Name),
+		zap.Stringer("object_id", info.ID()))
 }
 
 func parseCopyObjectArgs(headers http.Header) (*copyObjectArgs, error) {

--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -63,6 +63,11 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		h.logAndSendError(w, "could not parse request params", reqInfo, err)
 		return
 	}
+	p := &layer.HeadObjectParams{
+		Bucket:    srcBucket,
+		Object:    srcObject,
+		VersionID: reqInfo.URL.Query().Get("versionId"),
+	}
 
 	if args.MetadataDirective == replaceMetadataDirective {
 		metadata = parseMetadata(r)
@@ -80,7 +85,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if inf, err = h.obj.GetObjectInfo(r.Context(), srcBucket, srcObject); err != nil {
+	if inf, err = h.obj.GetObjectInfo(r.Context(), p); err != nil {
 		h.logAndSendError(w, "could not find object", reqInfo, err)
 		return
 	}
@@ -100,9 +105,8 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := &layer.CopyObjectParams{
-		SrcBucket: srcBucket,
+		SrcObject: inf,
 		DstBucket: reqInfo.BucketName,
-		SrcObject: srcObject,
 		DstObject: reqInfo.ObjectName,
 		SrcSize:   inf.Size,
 		Header:    metadata,

--- a/api/handler/delete.go
+++ b/api/handler/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // DeleteObjectsRequest - xml carrying the object key names which needs to be deleted.
@@ -21,6 +22,7 @@ type DeleteObjectsRequest struct {
 // ObjectIdentifier carries key name for the object to delete.
 type ObjectIdentifier struct {
 	ObjectName string `xml:"Key"`
+	VersionID  string `xml:"VersionId,omitempty"`
 }
 
 // DeleteError structure.
@@ -43,18 +45,22 @@ type DeleteObjectsResponse struct {
 
 func (h *handler) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 	reqInfo := api.GetReqInfo(r.Context())
+	versionedObject := []*layer.VersionedObject{{
+		Name:      reqInfo.ObjectName,
+		VersionID: reqInfo.URL.Query().Get("versionId"),
+	}}
 
 	if err := h.checkBucketOwner(r, reqInfo.BucketName); err != nil {
 		h.logAndSendError(w, "expected owner doesn't match", reqInfo, err)
 		return
 	}
 
-	if err := h.obj.DeleteObject(r.Context(), reqInfo.BucketName, reqInfo.ObjectName); err != nil {
+	if errs := h.obj.DeleteObjects(r.Context(), reqInfo.BucketName, versionedObject); len(errs) != 0 && errs[0] != nil {
 		h.log.Error("could not delete object",
 			zap.String("request_id", reqInfo.RequestID),
 			zap.String("bucket_name", reqInfo.BucketName),
 			zap.String("object_name", reqInfo.ObjectName),
-			zap.Error(err))
+			zap.Error(errs[0]))
 
 		// Ignore delete errors:
 
@@ -94,10 +100,14 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	removed := make(map[string]struct{})
-	toRemove := make([]string, 0, len(requested.Objects))
+	toRemove := make([]*layer.VersionedObject, 0, len(requested.Objects))
 	for _, obj := range requested.Objects {
-		removed[obj.ObjectName] = struct{}{}
-		toRemove = append(toRemove, obj.ObjectName)
+		versionedObj := &layer.VersionedObject{
+			Name:      obj.ObjectName,
+			VersionID: obj.VersionID,
+		}
+		toRemove = append(toRemove, versionedObj)
+		removed[versionedObj.String()] = struct{}{}
 	}
 
 	response := &DeleteObjectsResponse{
@@ -110,9 +120,16 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	marshaler := zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+		for _, obj := range toRemove {
+			encoder.AppendString(obj.String())
+		}
+		return nil
+	})
+
 	if errs := h.obj.DeleteObjects(r.Context(), reqInfo.BucketName, toRemove); errs != nil && !requested.Quiet {
 		additional := []zap.Field{
-			zap.Strings("objects_name", toRemove),
+			zap.Array("objects", marshaler),
 			zap.Errors("errors", errs),
 		}
 		h.logAndSendError(w, "could not delete objects", reqInfo, nil, additional...)
@@ -138,7 +155,7 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := api.EncodeToResponse(w, response); err != nil {
-		h.logAndSendError(w, "could not write response", reqInfo, err, zap.Strings("objects_name", toRemove))
+		h.logAndSendError(w, "could not write response", reqInfo, err, zap.Array("objects", marshaler))
 		return
 	}
 }

--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -72,7 +72,7 @@ func writeHeaders(h http.Header, info *layer.ObjectInfo) {
 	h.Set(api.LastModified, info.Created.UTC().Format(http.TimeFormat))
 	h.Set(api.ContentLength, strconv.FormatInt(info.Size, 10))
 	h.Set(api.ETag, info.HashSum)
-	h.Set(api.AmzVersionId, info.ID().String())
+	h.Set(api.AmzVersionID, info.ID().String())
 
 	for key, val := range info.Headers {
 		h[api.MetadataPrefix+key] = []string{val}

--- a/api/handler/head.go
+++ b/api/handler/head.go
@@ -46,18 +46,22 @@ func (h *handler) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 		h.logAndSendError(w, "could not fetch object info", reqInfo, err)
 		return
 	}
-	buffer := bytes.NewBuffer(make([]byte, 0, sizeToDetectType))
-	getParams := &layer.GetObjectParams{
-		ObjectInfo: inf,
-		Writer:     buffer,
-		Range:      getRangeToDetectContentType(inf.Size),
-		VersionID:  reqInfo.URL.Query().Get("versionId"),
+
+	if len(inf.ContentType) == 0 {
+		buffer := bytes.NewBuffer(make([]byte, 0, sizeToDetectType))
+		getParams := &layer.GetObjectParams{
+			ObjectInfo: inf,
+			Writer:     buffer,
+			Range:      getRangeToDetectContentType(inf.Size),
+			VersionID:  reqInfo.URL.Query().Get("versionId"),
+		}
+		if err = h.obj.GetObject(r.Context(), getParams); err != nil {
+			h.logAndSendError(w, "could not get object", reqInfo, err, zap.Stringer("oid", inf.ID()))
+			return
+		}
+		inf.ContentType = http.DetectContentType(buffer.Bytes())
 	}
-	if err = h.obj.GetObject(r.Context(), getParams); err != nil {
-		h.logAndSendError(w, "could not get object", reqInfo, err, zap.Stringer("oid", inf.ID()))
-		return
-	}
-	inf.ContentType = http.DetectContentType(buffer.Bytes())
+
 	writeHeaders(w.Header(), inf)
 	w.WriteHeader(http.StatusOK)
 }

--- a/api/handler/list.go
+++ b/api/handler/list.go
@@ -9,13 +9,6 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 )
 
-// VersioningConfiguration contains VersioningConfiguration XML representation.
-type VersioningConfiguration struct {
-	XMLName xml.Name `xml:"VersioningConfiguration"`
-	Text    string   `xml:",chardata"`
-	Xmlns   string   `xml:"xmlns,attr"`
-}
-
 // ListMultipartUploadsResult contains ListMultipartUploadsResult XML representation.
 type ListMultipartUploadsResult struct {
 	XMLName xml.Name `xml:"ListMultipartUploadsResult"`
@@ -58,20 +51,6 @@ func (h *handler) ListBucketsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err = api.EncodeToResponse(w, res); err != nil {
-		h.logAndSendError(w, "something went wrong", reqInfo, err)
-	}
-}
-
-// GetBucketVersioningHandler implements bucket versioning getter handler.
-func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
-	var (
-		reqInfo = api.GetReqInfo(r.Context())
-		res     = new(VersioningConfiguration)
-	)
-
-	res.Xmlns = "http://s3.amazonaws.com/doc/2006-03-01/"
-
-	if err := api.EncodeToResponse(w, res); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}
 }

--- a/api/handler/not_support.go
+++ b/api/handler/not_support.go
@@ -23,10 +23,6 @@ func (h *handler) PutBucketTaggingHandler(w http.ResponseWriter, r *http.Request
 	h.logAndSendError(w, "not supported", api.GetReqInfo(r.Context()), errors.GetAPIError(errors.ErrNotSupported))
 }
 
-func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
-	h.logAndSendError(w, "not supported", api.GetReqInfo(r.Context()), errors.GetAPIError(errors.ErrNotSupported))
-}
-
 func (h *handler) PutBucketNotificationHandler(w http.ResponseWriter, r *http.Request) {
 	h.logAndSendError(w, "not supported", api.GetReqInfo(r.Context()), errors.GetAPIError(errors.ErrNotSupported))
 }

--- a/api/handler/object_list.go
+++ b/api/handler/object_list.go
@@ -217,6 +217,16 @@ func (h *handler) ListBucketObjectVersionsHandler(w http.ResponseWriter, r *http
 		return
 	}
 
+	bktInfo, err := h.obj.GetBucketInfo(r.Context(), reqInfo.BucketName)
+	if err != nil {
+		h.logAndSendError(w, "could not get bucket info", reqInfo, err)
+		return
+	}
+	if err = checkOwner(bktInfo, r.Header.Get(api.AmzExpectedBucketOwner)); err != nil {
+		h.logAndSendError(w, "expected owner doesn't match", reqInfo, err)
+		return
+	}
+
 	info, err := h.obj.ListObjectVersions(r.Context(), p)
 	if err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)

--- a/api/handler/object_list.go
+++ b/api/handler/object_list.go
@@ -276,7 +276,7 @@ func encodeListObjectVersionsToResponse(info *layer.ListObjectVersionsInfo, buck
 				DisplayName: ver.Object.Owner.String(),
 			},
 			Size:      ver.Object.Size,
-			VersionID: ver.VersionID,
+			VersionID: ver.Object.Version(),
 			ETag:      ver.Object.HashSum,
 		})
 	}
@@ -284,13 +284,13 @@ func encodeListObjectVersionsToResponse(info *layer.ListObjectVersionsInfo, buck
 	for _, del := range info.DeleteMarker {
 		res.DeleteMarker = append(res.DeleteMarker, DeleteMarkerEntry{
 			IsLatest:     del.IsLatest,
-			Key:          del.Key,
-			LastModified: del.LastModified,
+			Key:          del.Object.Name,
+			LastModified: del.Object.Created.Format(time.RFC3339),
 			Owner: Owner{
-				ID:          del.Owner.String(),
-				DisplayName: del.Owner.String(),
+				ID:          del.Object.Owner.String(),
+				DisplayName: del.Object.Owner.String(),
 			},
-			VersionID: del.VersionID,
+			VersionID: del.Object.Version(),
 		})
 	}
 

--- a/api/handler/object_list.go
+++ b/api/handler/object_list.go
@@ -263,7 +263,7 @@ func encodeListObjectVersionsToResponse(info *layer.ListObjectVersionsInfo, buck
 	}
 
 	for _, prefix := range info.CommonPrefixes {
-		res.CommonPrefixes = append(res.CommonPrefixes, CommonPrefix{Prefix: *prefix})
+		res.CommonPrefixes = append(res.CommonPrefixes, CommonPrefix{Prefix: prefix})
 	}
 
 	for _, ver := range info.Version {

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -116,6 +116,12 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if versioning, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName); err != nil {
+		h.log.Warn("couldn't get bucket versioning", zap.String("bucket name", reqInfo.BucketName), zap.Error(err))
+	} else if versioning.VersioningEnabled {
+		w.Header().Set(api.AmzVersionID, info.Version())
+	}
+
 	w.Header().Set(api.ETag, info.HashSum)
 	api.WriteSuccessResponseHeadersOnly(w)
 }

--- a/api/handler/response.go
+++ b/api/handler/response.go
@@ -164,6 +164,13 @@ type ListObjectsVersionsResponse struct {
 	CommonPrefixes      []CommonPrefix          `xml:"CommonPrefixes"`
 }
 
+// VersioningConfiguration contains VersioningConfiguration XML representation.
+type VersioningConfiguration struct {
+	XMLName   xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ VersioningConfiguration"`
+	Status    string   `xml:"Status"`
+	MfaDelete string   `xml:"MfaDelete,omitempty"`
+}
+
 // MarshalXML - StringMap marshals into XML.
 func (s StringMap) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	tokens := []xml.Token{start}

--- a/api/handler/response.go
+++ b/api/handler/response.go
@@ -167,7 +167,7 @@ type ListObjectsVersionsResponse struct {
 // VersioningConfiguration contains VersioningConfiguration XML representation.
 type VersioningConfiguration struct {
 	XMLName   xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ VersioningConfiguration"`
-	Status    string   `xml:"Status"`
+	Status    string   `xml:"Status,omitempty"`
 	MfaDelete string   `xml:"MfaDelete,omitempty"`
 }
 

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/xml"
 	"net/http"
-	"strconv"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
@@ -20,8 +19,8 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	p := &layer.PutVersioningParams{
-		Bucket:            reqInfo.BucketName,
-		VersioningEnabled: configuration.Status == "Enabled",
+		Bucket:   reqInfo.BucketName,
+		Settings: &layer.BucketSettings{VersioningEnabled: configuration.Status == "Enabled"},
 	}
 
 	if _, err := h.obj.PutBucketVersioning(r.Context(), p); err != nil {
@@ -33,7 +32,7 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
 	reqInfo := api.GetReqInfo(r.Context())
 
-	objInfo, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName)
+	settings, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName)
 	if err != nil {
 		h.log.Warn("couldn't get version settings object: default version settings will be used",
 			zap.String("request_id", reqInfo.RequestID),
@@ -42,23 +41,18 @@ func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 			zap.Error(err))
 	}
 
-	if err = api.EncodeToResponse(w, formVersioningConfiguration(objInfo)); err != nil {
+	if err = api.EncodeToResponse(w, formVersioningConfiguration(settings)); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}
 }
 
-func formVersioningConfiguration(inf *layer.ObjectInfo) *VersioningConfiguration {
+func formVersioningConfiguration(settings *layer.BucketSettings) *VersioningConfiguration {
 	res := &VersioningConfiguration{Status: "Suspended"}
-
-	if inf == nil {
+	if settings == nil {
 		return res
 	}
-
-	enabled, ok := inf.Headers["S3-Settings-Versioning-enabled"]
-	if ok {
-		if parsed, err := strconv.ParseBool(enabled); err == nil && parsed {
-			res.Status = "Enabled"
-		}
+	if settings.VersioningEnabled {
+		res.Status = "Enabled"
 	}
 	return res
 }

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -39,6 +39,7 @@ func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 			zap.String("method", reqInfo.API),
 			zap.String("object_name", reqInfo.ObjectName),
 			zap.Error(err))
+		return
 	}
 
 	if err = api.EncodeToResponse(w, formVersioningConfiguration(settings)); err != nil {

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	"github.com/nspcc-dev/neofs-s3-gw/api"
+	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
+	"go.uber.org/zap"
+)
+
+func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
+	reqInfo := api.GetReqInfo(r.Context())
+
+	configuration := new(VersioningConfiguration)
+	if err := xml.NewDecoder(r.Body).Decode(configuration); err != nil {
+		h.logAndSendError(w, "couldn't decode versioning configuration", reqInfo, api.GetAPIError(api.ErrIllegalVersioningConfigurationException))
+		return
+	}
+
+	p := &layer.PutVersioningParams{
+		Bucket:            reqInfo.BucketName,
+		VersioningEnabled: configuration.Status == "Enabled",
+	}
+
+	if _, err := h.obj.PutBucketVersioning(r.Context(), p); err != nil {
+		h.logAndSendError(w, "couldn't put update versioning settings", reqInfo, err)
+	}
+}
+
+// GetBucketVersioningHandler implements bucket versioning getter handler.
+func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
+	reqInfo := api.GetReqInfo(r.Context())
+
+	objInfo, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName)
+	if err != nil {
+		h.log.Warn("couldn't get version settings object: default version settings will be used",
+			zap.String("request_id", reqInfo.RequestID),
+			zap.String("method", reqInfo.API),
+			zap.String("object_name", reqInfo.ObjectName),
+			zap.Error(err))
+	}
+
+	if err = api.EncodeToResponse(w, formVersioningConfiguration(objInfo)); err != nil {
+		h.logAndSendError(w, "something went wrong", reqInfo, err)
+	}
+}
+
+func formVersioningConfiguration(inf *layer.ObjectInfo) *VersioningConfiguration {
+	res := &VersioningConfiguration{Status: "Suspended"}
+
+	if inf == nil {
+		return res
+	}
+
+	enabled, ok := inf.Headers["S3-Settings-Versioning-enabled"]
+	if ok {
+		if parsed, err := strconv.ParseBool(enabled); err == nil && parsed {
+			res.Status = "Enabled"
+		}
+	}
+	return res
+}

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -24,6 +24,16 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 		Settings: &layer.BucketSettings{VersioningEnabled: configuration.Status == "Enabled"},
 	}
 
+	bktInfo, err := h.obj.GetBucketInfo(r.Context(), reqInfo.BucketName)
+	if err != nil {
+		h.logAndSendError(w, "could not get bucket info", reqInfo, err)
+		return
+	}
+	if err = checkOwner(bktInfo, r.Header.Get(api.AmzExpectedBucketOwner)); err != nil {
+		h.logAndSendError(w, "expected owner doesn't match", reqInfo, err)
+		return
+	}
+
 	if _, err := h.obj.PutBucketVersioning(r.Context(), p); err != nil {
 		h.logAndSendError(w, "couldn't put update versioning settings", reqInfo, err)
 	}
@@ -33,14 +43,27 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Request) {
 	reqInfo := api.GetReqInfo(r.Context())
 
+	bktInfo, err := h.obj.GetBucketInfo(r.Context(), reqInfo.BucketName)
+	if err != nil {
+		h.logAndSendError(w, "could not get bucket info", reqInfo, err)
+		return
+	}
+	if err = checkOwner(bktInfo, r.Header.Get(api.AmzExpectedBucketOwner)); err != nil {
+		h.logAndSendError(w, "expected owner doesn't match", reqInfo, err)
+		return
+	}
+
 	settings, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName)
 	if err != nil {
+		if errors.IsS3Error(err, errors.ErrNoSuchBucket) {
+			h.logAndSendError(w, "couldn't get versioning settings", reqInfo, err)
+			return
+		}
 		h.log.Warn("couldn't get version settings object: default version settings will be used",
 			zap.String("request_id", reqInfo.RequestID),
 			zap.String("method", reqInfo.API),
-			zap.String("object_name", reqInfo.ObjectName),
+			zap.String("bucket_name", reqInfo.BucketName),
 			zap.Error(err))
-		return
 	}
 
 	if err = api.EncodeToResponse(w, formVersioningConfiguration(settings)); err != nil {
@@ -49,12 +72,14 @@ func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 }
 
 func formVersioningConfiguration(settings *layer.BucketSettings) *VersioningConfiguration {
-	res := &VersioningConfiguration{Status: "Suspended"}
+	res := &VersioningConfiguration{}
 	if settings == nil {
 		return res
 	}
 	if settings.VersioningEnabled {
 		res.Status = "Enabled"
+	} else {
+		res.Status = "Suspended"
 	}
 	return res
 }

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
+	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
 	"go.uber.org/zap"
 )
@@ -14,7 +15,7 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 
 	configuration := new(VersioningConfiguration)
 	if err := xml.NewDecoder(r.Body).Decode(configuration); err != nil {
-		h.logAndSendError(w, "couldn't decode versioning configuration", reqInfo, api.GetAPIError(api.ErrIllegalVersioningConfigurationException))
+		h.logAndSendError(w, "couldn't decode versioning configuration", reqInfo, errors.GetAPIError(errors.ErrIllegalVersioningConfigurationException))
 		return
 	}
 

--- a/api/headers.go
+++ b/api/headers.go
@@ -4,7 +4,7 @@ package api
 const (
 	MetadataPrefix       = "X-Amz-Meta-"
 	AmzMetadataDirective = "X-Amz-Metadata-Directive"
-	AmzVersionId   = "X-Amz-Version-Id"
+	AmzVersionID   = "X-Amz-Version-Id"
 
 	LastModified       = "Last-Modified"
 	Date               = "Date"

--- a/api/headers.go
+++ b/api/headers.go
@@ -44,3 +44,8 @@ const (
 
 	ContainerID = "X-Container-Id"
 )
+
+// S3 request query params.
+const (
+	QueryVersionID = "versionId"
+)

--- a/api/headers.go
+++ b/api/headers.go
@@ -4,7 +4,7 @@ package api
 const (
 	MetadataPrefix       = "X-Amz-Meta-"
 	AmzMetadataDirective = "X-Amz-Metadata-Directive"
-	AmzVersionID   = "X-Amz-Version-Id"
+	AmzVersionID         = "X-Amz-Version-Id"
 
 	LastModified       = "Last-Modified"
 	Date               = "Date"

--- a/api/headers.go
+++ b/api/headers.go
@@ -4,6 +4,7 @@ package api
 const (
 	MetadataPrefix       = "X-Amz-Meta-"
 	AmzMetadataDirective = "X-Amz-Metadata-Directive"
+	AmzVersionId   = "X-Amz-Version-Id"
 
 	LastModified       = "Last-Modified"
 	Date               = "Date"

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -11,37 +11,29 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
-	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
+	"github.com/nspcc-dev/neofs-s3-gw/api/cache"
 	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-sdk-go/pkg/pool"
 	"go.uber.org/zap"
 )
 
 type (
-	// BucketInfo stores basic bucket data.
-	BucketInfo struct {
-		Name     string
-		CID      *cid.ID
-		Owner    *owner.ID
-		Created  time.Time
-		BasicACL uint32
-	}
 	// BucketACL extends BucketInfo by eacl.Table.
 	BucketACL struct {
-		Info *BucketInfo
+		Info *cache.BucketInfo
 		EACL *eacl.Table
 	}
 )
 
-func (n *layer) containerInfo(ctx context.Context, cid *cid.ID) (*BucketInfo, error) {
+func (n *layer) containerInfo(ctx context.Context, cid *cid.ID) (*cache.BucketInfo, error) {
 	var (
 		err       error
 		res       *container.Container
 		rid       = api.GetRequestID(ctx)
 		bearerOpt = n.BearerOpt(ctx)
 
-		info = &BucketInfo{
+		info = &cache.BucketInfo{
 			CID:  cid,
 			Name: cid.String(),
 		}
@@ -82,10 +74,17 @@ func (n *layer) containerInfo(ctx context.Context, cid *cid.ID) (*BucketInfo, er
 		}
 	}
 
+	if err := n.bucketCache.Put(info); err != nil {
+		n.log.Warn("could not put bucket info into cache",
+			zap.Stringer("cid", cid),
+			zap.String("bucket_name", info.Name),
+			zap.Error(err))
+	}
+
 	return info, nil
 }
 
-func (n *layer) containerList(ctx context.Context) ([]*BucketInfo, error) {
+func (n *layer) containerList(ctx context.Context) ([]*cache.BucketInfo, error) {
 	var (
 		err       error
 		own       = n.Owner(ctx)
@@ -101,7 +100,7 @@ func (n *layer) containerList(ctx context.Context) ([]*BucketInfo, error) {
 		return nil, err
 	}
 
-	list := make([]*BucketInfo, 0, len(res))
+	list := make([]*cache.BucketInfo, 0, len(res))
 	for _, cid := range res {
 		info, err := n.containerInfo(ctx, cid)
 		if err != nil {

--- a/api/layer/detector.go
+++ b/api/layer/detector.go
@@ -3,24 +3,56 @@ package layer
 import (
 	"io"
 	"net/http"
-	"sync"
 )
 
-type detector struct {
-	io.Reader
-	sync.Once
+type (
+	detector struct {
+		io.Reader
+		err  error
+		data []byte
+	}
+	errReader struct {
+		data   []byte
+		err    error
+		offset int
+	}
+)
 
-	contentType string
+const contentTypeDetectSize = 512
+
+func newReader(data []byte, err error) *errReader {
+	return &errReader{data: data, err: err}
 }
 
-func newDetector(r io.Reader) *detector {
-	return &detector{Reader: r}
+func (r *errReader) Read(b []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(b, r.data[r.offset:])
+	r.offset += n
+	if r.offset >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
 }
 
-func (d *detector) Read(data []byte) (int, error) {
-	d.Do(func() {
-		d.contentType = http.DetectContentType(data)
-	})
+func newDetector(reader io.Reader) *detector {
+	return &detector{
+		data:   make([]byte, contentTypeDetectSize),
+		Reader: reader,
+	}
+}
 
-	return d.Reader.Read(data)
+func (d *detector) Detect() (string, error) {
+	n, err := d.Reader.Read(d.data)
+	if err != nil && err != io.EOF {
+		d.err = err
+		return "", err
+	}
+	d.data = d.data[:n]
+	return http.DetectContentType(d.data), nil
+}
+
+func (d *detector) MultiReader() io.Reader {
+	return io.MultiReader(newReader(d.data, d.err), d.Reader)
 }

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
@@ -32,7 +29,7 @@ type (
 		log         *zap.Logger
 		listsCache  ObjectsListCache
 		objCache    cache.ObjectsCache
-		headCache   cache.HeadObjectsCache
+		namesCache  cache.ObjectsNameCache
 		bucketCache cache.BucketCache
 		systemCache cache.SystemCache
 	}
@@ -56,12 +53,10 @@ type (
 	GetObjectParams struct {
 		Range      *RangeParams
 		ObjectInfo *ObjectInfo
-		//Bucket    string
-		//Object    string
-		Offset    int64
-		Length    int64
-		Writer    io.Writer
-		VersionID string
+		Offset     int64
+		Length     int64
+		Writer     io.Writer
+		VersionID  string
 	}
 
 	// HeadObjectParams stores object head request parameters.
@@ -139,14 +134,6 @@ type (
 		VersionID string
 	}
 
-	objectVersions struct {
-		name     string
-		objects  []*ObjectInfo
-		addList  []string
-		delList  []string
-		isSorted bool
-	}
-
 	// NeoFS provides basic NeoFS interface.
 	NeoFS interface {
 		Get(ctx context.Context, address *object.Address) (*object.Object, error)
@@ -181,95 +168,6 @@ type (
 	}
 )
 
-func newObjectVersions(name string) *objectVersions {
-	return &objectVersions{name: name}
-}
-
-func (v *objectVersions) appendVersion(oi *ObjectInfo) {
-	addVers := append(splitVersions(oi.Headers[versionsAddAttr]), oi.Version())
-	delVers := splitVersions(oi.Headers[versionsDelAttr])
-	v.objects = append(v.objects, oi)
-	for _, add := range addVers {
-		if !contains(v.addList, add) {
-			v.addList = append(v.addList, add)
-		}
-	}
-	for _, del := range delVers {
-		if !contains(v.delList, del) {
-			v.delList = append(v.delList, del)
-		}
-	}
-	v.isSorted = false
-}
-
-func (v *objectVersions) sort() {
-	if !v.isSorted {
-		sortVersions(v.objects)
-		v.isSorted = true
-	}
-}
-
-func (v *objectVersions) getLast() *ObjectInfo {
-	if len(v.objects) == 0 {
-		return nil
-	}
-
-	v.sort()
-	existedVersions := getExistedVersions(v)
-	for i := len(v.objects) - 1; i >= 0; i-- {
-		if contains(existedVersions, v.objects[i].Version()) {
-			delMarkHeader := v.objects[i].Headers[versionsDeleteMarkAttr]
-			if delMarkHeader == "" {
-				return v.objects[i]
-			}
-			if delMarkHeader == delMarkFullObject {
-				return nil
-			}
-		}
-	}
-
-	return nil
-}
-
-func (v *objectVersions) getFiltered() []*ObjectInfo {
-	if len(v.objects) == 0 {
-		return nil
-	}
-
-	v.sort()
-	existedVersions := getExistedVersions(v)
-	res := make([]*ObjectInfo, 0, len(v.objects))
-
-	for _, version := range v.objects {
-		delMark := version.Headers[versionsDeleteMarkAttr]
-		if contains(existedVersions, version.Version()) && (delMark == delMarkFullObject || delMark == "") {
-			res = append(res, version)
-		}
-	}
-
-	return res
-}
-
-func (v *objectVersions) getAddHeader() string {
-	return strings.Join(v.addList, ",")
-}
-
-func (v *objectVersions) getDelHeader() string {
-	return strings.Join(v.delList, ",")
-}
-
-const (
-	unversionedObjectVersionID    = "null"
-	bktVersionSettingsObject      = ".s3-versioning-settings"
-	objectSystemAttributeName     = "S3-System-name"
-	attrVersionsIgnore            = "S3-Versions-ignore"
-	attrSettingsVersioningEnabled = "S3-Settings-Versioning-enabled"
-	versionsDelAttr               = "S3-Versions-del"
-	versionsAddAttr               = "S3-Versions-add"
-	versionsDeleteMarkAttr        = "S3-Versions-delete-mark"
-	delMarkFullObject             = "*"
-)
-
 func (t *VersionedObject) String() string {
 	return t.Name + ":" + t.VersionID
 }
@@ -283,7 +181,7 @@ func NewLayer(log *zap.Logger, conns pool.Pool, config *CacheConfig) Client {
 		listsCache: newListObjectsCache(config.ListObjectsLifetime),
 		objCache:   cache.New(config.Size, config.Lifetime),
 		//todo reconsider cache params
-		headCache:   cache.NewHeadObject(1000, time.Minute),
+		namesCache:  cache.NewObjectsNameCache(1000, time.Minute),
 		bucketCache: cache.NewBucketCache(150, time.Minute),
 		systemCache: cache.NewSystemCache(1000, 5*time.Minute),
 	}
@@ -432,11 +330,11 @@ func (n *layer) GetObjectInfo(ctx context.Context, p *HeadObjectParams) (*Object
 }
 
 func (n *layer) getSettingsObjectInfo(ctx context.Context, bkt *cache.BucketInfo) (*ObjectInfo, error) {
-	if meta := n.systemCache.Get(bktVersionSettingsObject); meta != nil {
+	if meta := n.systemCache.Get(bkt.SettingsObjectKey()); meta != nil {
 		return objInfoFromMeta(bkt, meta), nil
 	}
 
-	oid, err := n.objectFindID(ctx, &findParams{cid: bkt.CID, attr: objectSystemAttributeName, val: bktVersionSettingsObject})
+	oid, err := n.objectFindID(ctx, &findParams{cid: bkt.CID, attr: objectSystemAttributeName, val: bkt.SettingsObjectName()})
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +344,7 @@ func (n *layer) getSettingsObjectInfo(ctx context.Context, bkt *cache.BucketInfo
 		n.log.Error("could not fetch object head", zap.Error(err))
 		return nil, err
 	}
-	if err = n.systemCache.Put(bktVersionSettingsObject, meta); err != nil {
+	if err = n.systemCache.Put(bkt.SettingsObjectKey(), meta); err != nil {
 		n.log.Error("couldn't cache system object", zap.Error(err))
 	}
 
@@ -506,7 +404,7 @@ func (n *layer) deleteObject(ctx context.Context, bkt *cache.BucketInfo, obj *Ve
 			Header: map[string]string{versionsDeleteMarkAttr: obj.VersionID},
 		}
 		if len(obj.VersionID) != 0 {
-			id, err := n.checkVersionsExists(ctx, bkt, obj)
+			id, err := n.checkVersionsExist(ctx, bkt, obj)
 			if err != nil {
 				return err
 			}
@@ -517,39 +415,22 @@ func (n *layer) deleteObject(ctx context.Context, bkt *cache.BucketInfo, obj *Ve
 			p.Header[versionsDeleteMarkAttr] = delMarkFullObject
 		}
 		if _, err = n.objectPut(ctx, bkt, p); err != nil {
-			return &errors.DeleteError{Err: err, Object: obj.String()}
+			return err
 		}
 	} else {
 		ids, err = n.objectSearch(ctx, &findParams{cid: bkt.CID, val: obj.Name})
 		if err != nil {
-			return &errors.DeleteError{Err: err, Object: obj.String()}
+			return err
 		}
 	}
 
 	for _, id := range ids {
 		if err = n.objectDelete(ctx, bkt.CID, id); err != nil {
-			return &errors.DeleteError{Err: err, Object: obj.String()}
+			return err
 		}
 	}
 
 	return nil
-}
-
-func (n *layer) checkVersionsExists(ctx context.Context, bkt *cache.BucketInfo, obj *VersionedObject) (*object.ID, error) {
-	id := object.NewID()
-	if err := id.Parse(obj.VersionID); err != nil {
-		return nil, &errors.DeleteError{Err: errors.GetAPIError(errors.ErrInvalidVersion), Object: obj.String()}
-	}
-
-	versions, err := n.headVersions(ctx, bkt, obj.Name)
-	if err != nil {
-		return nil, &errors.DeleteError{Err: err, Object: obj.String()}
-	}
-	if !contains(getExistedVersions(versions), obj.VersionID) {
-		return nil, &errors.DeleteError{Err: errors.GetAPIError(errors.ErrInvalidVersion), Object: obj.String()}
-	}
-
-	return id, nil
 }
 
 // DeleteObjects from the storage.
@@ -561,9 +442,9 @@ func (n *layer) DeleteObjects(ctx context.Context, bucket string, objects []*Ver
 		return append(errs, err)
 	}
 
-	for i := range objects {
-		if err := n.deleteObject(ctx, bkt, objects[i]); err != nil {
-			errs = append(errs, err)
+	for _, obj := range objects {
+		if err := n.deleteObject(ctx, bkt, obj); err != nil {
+			errs = append(errs, &errors.ObjectError{Err: err, Object: obj.Name, Version: obj.VersionID})
 		}
 	}
 
@@ -588,210 +469,17 @@ func (n *layer) DeleteBucket(ctx context.Context, p *DeleteBucketParams) error {
 		return err
 	}
 
-	ids, err := n.objectSearch(ctx, &findParams{cid: bucketInfo.CID})
+	objects, err := n.listSortedObjectsFromNeoFS(ctx, allObjectParams{Bucket: bucketInfo})
 	if err != nil {
 		return err
 	}
-	if len(ids) != 0 {
+	if len(objects) != 0 {
 		return errors.GetAPIError(errors.ErrBucketNotEmpty)
 	}
 
-	return n.deleteContainer(ctx, bucketInfo.CID)
-}
-
-func (n *layer) ListObjectVersions(ctx context.Context, p *ListObjectVersionsParams) (*ListObjectVersionsInfo, error) {
-	var versions map[string]*objectVersions
-	res := &ListObjectVersionsInfo{}
-
-	bkt, err := n.GetBucketInfo(ctx, p.Bucket)
-	if err != nil {
-		return nil, err
+	if err = n.deleteContainer(ctx, bucketInfo.CID); err != nil {
+		return err
 	}
-
-	cacheKey, err := createKey(ctx, bkt.CID, listVersionsMethod, p.Prefix, p.Delimiter)
-	if err != nil {
-		return nil, err
-	}
-
-	allObjects := n.listsCache.Get(cacheKey)
-	if allObjects == nil {
-		versions, err = n.getAllObjectsVersions(ctx, bkt, p.Prefix, p.Delimiter)
-		if err != nil {
-			return nil, err
-		}
-
-		sortedNames := make([]string, 0, len(versions))
-		for k := range versions {
-			sortedNames = append(sortedNames, k)
-		}
-		sort.Strings(sortedNames)
-
-		allObjects = make([]*ObjectInfo, 0, p.MaxKeys)
-		for _, name := range sortedNames {
-			allObjects = append(allObjects, versions[name].getFiltered()...)
-		}
-
-		// putting to cache a copy of allObjects because allObjects can be modified further
-		n.listsCache.Put(cacheKey, append([]*ObjectInfo(nil), allObjects...))
-	}
-
-	for i, obj := range allObjects {
-		if obj.Name >= p.KeyMarker && obj.Version() >= p.VersionIDMarker {
-			allObjects = allObjects[i:]
-			break
-		}
-	}
-
-	res.CommonPrefixes, allObjects = triageObjects(allObjects)
-
-	if len(allObjects) > p.MaxKeys {
-		res.IsTruncated = true
-		res.NextKeyMarker = allObjects[p.MaxKeys].Name
-		res.NextVersionIDMarker = allObjects[p.MaxKeys].Version()
-
-		allObjects = allObjects[:p.MaxKeys]
-		res.KeyMarker = allObjects[p.MaxKeys-1].Name
-		res.VersionIDMarker = allObjects[p.MaxKeys-1].Version()
-	}
-
-	objects := make([]*ObjectVersionInfo, len(allObjects))
-	for i, obj := range allObjects {
-		objects[i] = &ObjectVersionInfo{Object: obj}
-		if i == len(allObjects)-1 || allObjects[i+1].Name != obj.Name {
-			objects[i].IsLatest = true
-		}
-	}
-
-	res.Version, res.DeleteMarker = triageVersions(objects)
-	return res, nil
-}
-
-func sortVersions(versions []*ObjectInfo) {
-	sort.Slice(versions, func(i, j int) bool {
-		return less(versions[i], versions[j])
-	})
-}
-
-func triageVersions(objVersions []*ObjectVersionInfo) ([]*ObjectVersionInfo, []*ObjectVersionInfo) {
-	if len(objVersions) == 0 {
-		return nil, nil
-	}
-
-	var resVersion []*ObjectVersionInfo
-	var resDelMarkVersions []*ObjectVersionInfo
-
-	for _, version := range objVersions {
-		if version.Object.Headers[versionsDeleteMarkAttr] == delMarkFullObject {
-			resDelMarkVersions = append(resDelMarkVersions, version)
-		} else {
-			resVersion = append(resVersion, version)
-		}
-	}
-
-	return resVersion, resDelMarkVersions
-}
-
-func less(ov1, ov2 *ObjectInfo) bool {
-	if ov1.CreationEpoch == ov2.CreationEpoch {
-		return ov1.Version() < ov2.Version()
-	}
-	return ov1.CreationEpoch < ov2.CreationEpoch
-}
-
-func contains(list []string, elem string) bool {
-	for _, item := range list {
-		if elem == item {
-			return true
-		}
-	}
-	return false
-}
-
-func (n *layer) PutBucketVersioning(ctx context.Context, p *PutVersioningParams) (*ObjectInfo, error) {
-	bucketInfo, err := n.GetBucketInfo(ctx, p.Bucket)
-	if err != nil {
-		return nil, err
-	}
-
-	objectInfo, err := n.getSettingsObjectInfo(ctx, bucketInfo)
-	if err != nil {
-		n.log.Warn("couldn't get bucket version settings object, new one will be created",
-			zap.String("bucket_name", bucketInfo.Name),
-			zap.Stringer("cid", bucketInfo.CID),
-			zap.Error(err))
-	}
-
-	attributes := make([]*object.Attribute, 0, 3)
-
-	filename := object.NewAttribute()
-	filename.SetKey(objectSystemAttributeName)
-	filename.SetValue(bktVersionSettingsObject)
-
-	createdAt := object.NewAttribute()
-	createdAt.SetKey(object.AttributeTimestamp)
-	createdAt.SetValue(strconv.FormatInt(time.Now().UTC().Unix(), 10))
-
-	versioningIgnore := object.NewAttribute()
-	versioningIgnore.SetKey(attrVersionsIgnore)
-	versioningIgnore.SetValue(strconv.FormatBool(true))
-
-	settingsVersioningEnabled := object.NewAttribute()
-	settingsVersioningEnabled.SetKey(attrSettingsVersioningEnabled)
-	settingsVersioningEnabled.SetValue(strconv.FormatBool(p.Settings.VersioningEnabled))
-
-	attributes = append(attributes, filename, createdAt, versioningIgnore, settingsVersioningEnabled)
-
-	raw := object.NewRaw()
-	raw.SetOwnerID(bucketInfo.Owner)
-	raw.SetContainerID(bucketInfo.CID)
-	raw.SetAttributes(attributes...)
-
-	ops := new(client.PutObjectParams).WithObject(raw.Object())
-	oid, err := n.pool.PutObject(ctx, ops, n.BearerOpt(ctx))
-	if err != nil {
-		return nil, err
-	}
-
-	meta, err := n.objectHead(ctx, bucketInfo.CID, oid)
-	if err != nil {
-		return nil, err
-	}
-
-	if objectInfo != nil {
-		if err = n.objectDelete(ctx, bucketInfo.CID, objectInfo.ID()); err != nil {
-			return nil, err
-		}
-	}
-
-	return objectInfoFromMeta(bucketInfo, meta, "", ""), nil
-}
-
-func (n *layer) GetBucketVersioning(ctx context.Context, bucketName string) (*BucketSettings, error) {
-	bktInfo, err := n.GetBucketInfo(ctx, bucketName)
-	if err != nil {
-		return nil, err
-	}
-
-	return n.getBucketSettings(ctx, bktInfo)
-}
-
-func (n *layer) getBucketSettings(ctx context.Context, bktInfo *cache.BucketInfo) (*BucketSettings, error) {
-	objInfo, err := n.getSettingsObjectInfo(ctx, bktInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	return objectInfoToBucketSettings(objInfo), nil
-}
-
-func objectInfoToBucketSettings(info *ObjectInfo) *BucketSettings {
-	res := &BucketSettings{}
-
-	enabled, ok := info.Headers["S3-Settings-Versioning-enabled"]
-	if ok {
-		if parsed, err := strconv.ParseBool(enabled); err == nil {
-			res.VersioningEnabled = parsed
-		}
-	}
-	return res
+	n.bucketCache.Delete(bucketInfo.Name)
+	return nil
 }

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -64,12 +64,6 @@ type (
 	}
 )
 
-const (
-	versionsDelAttr        = "S3-Versions-del"
-	versionsAddAttr        = "S3-Versions-add"
-	versionsDeleteMarkAttr = "S3-Versions-delete-mark"
-)
-
 // objectSearch returns all available objects by search params.
 func (n *layer) objectSearch(ctx context.Context, p *findParams) ([]*object.ID, error) {
 	var opts object.SearchFilters
@@ -272,7 +266,7 @@ func (n *layer) headVersions(ctx context.Context, bkt *BucketInfo, objectName st
 		return nil, apiErrors.GetAPIError(apiErrors.ErrNoSuchKey)
 	}
 
-	versions := &objectVersions{}
+	versions := newObjectVersions(objectName)
 	for _, id := range ids {
 		meta, err := n.objectHead(ctx, bkt.CID, id)
 		if err != nil {
@@ -418,7 +412,7 @@ func (n *layer) listSortedObjectsFromNeoFS(ctx context.Context, p allObjectParam
 				objVersions.appendVersion(oi)
 				versions[oi.Name] = objVersions
 			} else {
-				objVersion := &objectVersions{}
+				objVersion := newObjectVersions(oi.Name)
 				objVersion.appendVersion(oi)
 				versions[oi.Name] = objVersion
 			}

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -252,7 +252,7 @@ func (n *layer) headLastVersion(ctx context.Context, bkt *BucketInfo, objectName
 	}
 
 	if len(ids) == 0 {
-		return nil, api.GetAPIError(api.ErrNoSuchKey)
+		return nil, apiErrors.GetAPIError(apiErrors.ErrNoSuchKey)
 	}
 
 	infos := make([]*object.Object, 0, len(ids))
@@ -284,7 +284,7 @@ func (n *layer) headVersion(ctx context.Context, bkt *BucketInfo, versionID stri
 	meta, err := n.objectHead(ctx, bkt.CID, oid)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return nil, api.GetAPIError(api.ErrNoSuchVersion)
+			return nil, apiErrors.GetAPIError(apiErrors.ErrNoSuchVersion)
 		}
 		return nil, err
 	}

--- a/api/layer/object_list_cache.go
+++ b/api/layer/object_list_cache.go
@@ -30,6 +30,11 @@ type (
 // DefaultObjectsListCacheLifetime is a default lifetime of entries in cache of ListObjects.
 const DefaultObjectsListCacheLifetime = time.Second * 60
 
+const (
+	listObjectsMethod  = "listObjects"
+	listVersionsMethod = "listVersions"
+)
+
 type (
 	listObjectsCache struct {
 		cacheLifetime time.Duration
@@ -78,7 +83,7 @@ func (l *listObjectsCache) Put(key cacheOptions, objects []*ObjectInfo) {
 	})
 }
 
-func createKey(ctx context.Context, cid *cid.ID, prefix, delimiter string) (cacheOptions, error) {
+func createKey(ctx context.Context, cid *cid.ID, method, prefix, delimiter string) (cacheOptions, error) {
 	box, err := GetBoxData(ctx)
 	if err != nil {
 		return cacheOptions{}, err

--- a/api/layer/object_list_cache.go
+++ b/api/layer/object_list_cache.go
@@ -45,6 +45,7 @@ type (
 		list []*ObjectInfo
 	}
 	cacheOptions struct {
+		method    string
 		key       string
 		delimiter string
 		prefix    string
@@ -89,6 +90,7 @@ func createKey(ctx context.Context, cid *cid.ID, method, prefix, delimiter strin
 		return cacheOptions{}, err
 	}
 	p := cacheOptions{
+		method:    method,
 		key:       box.Gate.AccessKey + cid.String(),
 		delimiter: delimiter,
 		prefix:    prefix,

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
-
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
@@ -19,18 +18,19 @@ import (
 type (
 	// ObjectInfo holds S3 object data.
 	ObjectInfo struct {
-		id    *object.ID
-		isDir bool
+		id       *object.ID
+		bucketID *cid.ID
+		isDir    bool
 
-		Bucket      string
-		bucketID    *cid.ID
-		Name        string
-		Size        int64
-		ContentType string
-		Created     time.Time
-		HashSum     string
-		Owner       *owner.ID
-		Headers     map[string]string
+		Bucket        string
+		Name          string
+		Size          int64
+		ContentType   string
+		Created       time.Time
+		CreationEpoch uint64
+		HashSum       string
+		Owner         *owner.ID
+		Headers       map[string]string
 	}
 
 	// ListObjectsInfo contains common fields of data for ListObjectsV1 and ListObjectsV2.
@@ -54,19 +54,8 @@ type (
 
 	// ObjectVersionInfo stores info about objects versions.
 	ObjectVersionInfo struct {
-		Object        *ObjectInfo
-		IsLatest      bool
-		VersionID     string
-		CreationEpoch uint64
-	}
-
-	// DeletedObjectInfo stores info about deleted versions of objects.
-	DeletedObjectInfo struct {
-		Owner        *owner.ID
-		Key          string
-		VersionID    string
-		IsLatest     bool
-		LastModified string
+		Object   *ObjectInfo
+		IsLatest bool
 	}
 
 	// ListObjectVersionsInfo stores info and list of objects' versions.
@@ -77,7 +66,7 @@ type (
 		NextKeyMarker       string
 		NextVersionIDMarker string
 		Version             []*ObjectVersionInfo
-		DeleteMarker        []*DeletedObjectInfo
+		DeleteMarker        []*ObjectVersionInfo
 		VersionIDMarker     string
 	}
 )
@@ -137,27 +126,20 @@ func objectInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, delimiter 
 	}
 
 	return &ObjectInfo{
-		id:    meta.ID(),
-		isDir: isDir,
+		id:       meta.ID(),
+		bucketID: bkt.CID,
+		isDir:    isDir,
 
-		Bucket:      bkt.Name,
-		bucketID:    bkt.CID,
-		Name:        filename,
-		Created:     creation,
-		ContentType: mimeType,
-		Headers:     userHeaders,
-		Owner:       meta.OwnerID(),
-		Size:        size,
-		HashSum:     meta.PayloadChecksum().String(),
+		Bucket:        bkt.Name,
+		Name:          filename,
+		Created:       creation,
+		CreationEpoch: meta.CreationEpoch(),
+		ContentType:   mimeType,
+		Headers:       userHeaders,
+		Owner:         meta.OwnerID(),
+		Size:          size,
+		HashSum:       meta.PayloadChecksum().String(),
 	}
-}
-
-func objectVersionInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, delimiter string) *ObjectVersionInfo {
-	oi := objectInfoFromMeta(bkt, meta, prefix, delimiter)
-	if oi == nil {
-		return nil
-	}
-	return &ObjectVersionInfo{Object: oi, VersionID: meta.ID().String(), CreationEpoch: meta.CreationEpoch()}
 }
 
 func filenameFromObject(o *object.Object) string {
@@ -178,6 +160,9 @@ func NameFromString(name string) (string, string) {
 
 // ID returns object ID from ObjectInfo.
 func (o *ObjectInfo) ID() *object.ID { return o.id }
+
+// Version returns object version from ObjectInfo.
+func (o *ObjectInfo) Version() string { return o.id.String() }
 
 // CID returns bucket ID from ObjectInfo.
 func (o *ObjectInfo) CID() *cid.ID { return o.bucketID }

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -54,9 +54,10 @@ type (
 
 	// ObjectVersionInfo stores info about objects versions.
 	ObjectVersionInfo struct {
-		Object    *ObjectInfo
-		IsLatest  bool
-		VersionID string
+		Object        *ObjectInfo
+		IsLatest      bool
+		VersionID     string
+		CreationEpoch uint64
 	}
 
 	// DeletedObjectInfo stores info about deleted versions of objects.
@@ -156,7 +157,7 @@ func objectVersionInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, del
 	if oi == nil {
 		return nil
 	}
-	return &ObjectVersionInfo{Object: oi, IsLatest: true, VersionID: unversionedObjectVersionID}
+	return &ObjectVersionInfo{Object: oi, VersionID: meta.ID().String(), CreationEpoch: meta.CreationEpoch()}
 }
 
 func filenameFromObject(o *object.Object) string {

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
+
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
@@ -21,6 +23,7 @@ type (
 		isDir bool
 
 		Bucket      string
+		bucketID    *cid.ID
 		Name        string
 		Size        int64
 		ContentType string
@@ -137,6 +140,7 @@ func objectInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, delimiter 
 		isDir: isDir,
 
 		Bucket:      bkt.Name,
+		bucketID:    bkt.CID,
 		Name:        filename,
 		Created:     creation,
 		ContentType: mimeType,
@@ -173,6 +177,9 @@ func NameFromString(name string) (string, string) {
 
 // ID returns object ID from ObjectInfo.
 func (o *ObjectInfo) ID() *object.ID { return o.id }
+
+// CID returns bucket ID from ObjectInfo.
+func (o *ObjectInfo) CID() *cid.ID { return o.bucketID }
 
 // IsDir allows to check if object is a directory.
 func (o *ObjectInfo) IsDir() bool { return o.isDir }

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
+	"github.com/nspcc-dev/neofs-s3-gw/api/cache"
 	"github.com/nspcc-dev/neofs-s3-gw/creds/accessbox"
 )
 
@@ -60,7 +61,7 @@ type (
 
 	// ListObjectVersionsInfo stores info and list of objects' versions.
 	ListObjectVersionsInfo struct {
-		CommonPrefixes      []*string
+		CommonPrefixes      []string
 		IsTruncated         bool
 		KeyMarker           string
 		NextKeyMarker       string
@@ -84,7 +85,11 @@ func userHeaders(attrs []*object.Attribute) map[string]string {
 	return result
 }
 
-func objectInfoFromMeta(bkt *BucketInfo, meta *object.Object, prefix, delimiter string) *ObjectInfo {
+func objInfoFromMeta(bkt *cache.BucketInfo, meta *object.Object) *ObjectInfo {
+	return objectInfoFromMeta(bkt, meta, "", "")
+}
+
+func objectInfoFromMeta(bkt *cache.BucketInfo, meta *object.Object, prefix, delimiter string) *ObjectInfo {
 	var (
 		isDir    bool
 		size     int64
@@ -163,6 +168,12 @@ func (o *ObjectInfo) ID() *object.ID { return o.id }
 
 // Version returns object version from ObjectInfo.
 func (o *ObjectInfo) Version() string { return o.id.String() }
+
+// NiceName returns object name for cache.
+func (o *ObjectInfo) NiceName() string { return o.Bucket + "/" + o.Name }
+
+// Address returns object address.
+func (o *ObjectInfo) Address() *object.Address { return newAddress(o.bucketID, o.id) }
 
 // CID returns bucket ID from ObjectInfo.
 func (o *ObjectInfo) CID() *cid.ID { return o.bucketID }

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -48,6 +48,7 @@ func newTestInfo(oid *object.ID, bkt *BucketInfo, name string, isDir bool) *Obje
 		id:          oid,
 		Name:        name,
 		Bucket:      bkt.Name,
+		bucketID:    bkt.CID,
 		Size:        defaultTestPayloadLength,
 		ContentType: defaultTestContentType,
 		Created:     time.Unix(defaultTestCreated.Unix(), 0),

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -9,6 +9,7 @@ import (
 	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-s3-gw/api/cache"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ var (
 	defaultTestContentType   = http.DetectContentType(defaultTestPayload)
 )
 
-func newTestObject(oid *object.ID, bkt *BucketInfo, name string) *object.Object {
+func newTestObject(oid *object.ID, bkt *cache.BucketInfo, name string) *object.Object {
 	filename := object.NewAttribute()
 	filename.SetKey(object.AttributeFileName)
 	filename.SetValue(name)
@@ -43,7 +44,7 @@ func newTestObject(oid *object.ID, bkt *BucketInfo, name string) *object.Object 
 	return raw.Object()
 }
 
-func newTestInfo(oid *object.ID, bkt *BucketInfo, name string, isDir bool) *ObjectInfo {
+func newTestInfo(oid *object.ID, bkt *cache.BucketInfo, name string, isDir bool) *ObjectInfo {
 	info := &ObjectInfo{
 		id:          oid,
 		Name:        name,
@@ -71,7 +72,7 @@ func Test_objectInfoFromMeta(t *testing.T) {
 	oid := object.NewID()
 	containerID := cid.New()
 
-	bkt := &BucketInfo{
+	bkt := &cache.BucketInfo{
 		Name:    "test-container",
 		CID:     containerID,
 		Owner:   uid,

--- a/api/layer/versioning.go
+++ b/api/layer/versioning.go
@@ -1,0 +1,325 @@
+package layer
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-s3-gw/api/cache"
+	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
+	"go.uber.org/zap"
+)
+
+type objectVersions struct {
+	name     string
+	objects  []*ObjectInfo
+	addList  []string
+	delList  []string
+	isSorted bool
+}
+
+const (
+	unversionedObjectVersionID    = "null"
+	objectSystemAttributeName     = "S3-System-name"
+	attrVersionsIgnore            = "S3-Versions-ignore"
+	attrSettingsVersioningEnabled = "S3-Settings-Versioning-enabled"
+	versionsDelAttr               = "S3-Versions-del"
+	versionsAddAttr               = "S3-Versions-add"
+	versionsDeleteMarkAttr        = "S3-Versions-delete-mark"
+	delMarkFullObject             = "*"
+)
+
+func newObjectVersions(name string) *objectVersions {
+	return &objectVersions{name: name}
+}
+
+func (v *objectVersions) appendVersion(oi *ObjectInfo) {
+	addVers := append(splitVersions(oi.Headers[versionsAddAttr]), oi.Version())
+	delVers := splitVersions(oi.Headers[versionsDelAttr])
+	v.objects = append(v.objects, oi)
+	for _, add := range addVers {
+		if !contains(v.addList, add) {
+			v.addList = append(v.addList, add)
+		}
+	}
+	for _, del := range delVers {
+		if !contains(v.delList, del) {
+			v.delList = append(v.delList, del)
+		}
+	}
+	v.isSorted = false
+}
+
+func (v *objectVersions) sort() {
+	if !v.isSorted {
+		sort.Slice(v.objects, func(i, j int) bool {
+			return less(v.objects[i], v.objects[j])
+		})
+		v.isSorted = true
+	}
+}
+
+func (v *objectVersions) getLast() *ObjectInfo {
+	if len(v.objects) == 0 {
+		return nil
+	}
+
+	v.sort()
+	existedVersions := getExistedVersions(v)
+	for i := len(v.objects) - 1; i >= 0; i-- {
+		if contains(existedVersions, v.objects[i].Version()) {
+			delMarkHeader := v.objects[i].Headers[versionsDeleteMarkAttr]
+			if delMarkHeader == "" {
+				return v.objects[i]
+			}
+			if delMarkHeader == delMarkFullObject {
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func (v *objectVersions) getFiltered() []*ObjectInfo {
+	if len(v.objects) == 0 {
+		return nil
+	}
+
+	v.sort()
+	existedVersions := getExistedVersions(v)
+	res := make([]*ObjectInfo, 0, len(v.objects))
+
+	for _, version := range v.objects {
+		delMark := version.Headers[versionsDeleteMarkAttr]
+		if contains(existedVersions, version.Version()) && (delMark == delMarkFullObject || delMark == "") {
+			res = append(res, version)
+		}
+	}
+
+	return res
+}
+
+func (v *objectVersions) getAddHeader() string {
+	return strings.Join(v.addList, ",")
+}
+
+func (v *objectVersions) getDelHeader() string {
+	return strings.Join(v.delList, ",")
+}
+
+func (n *layer) PutBucketVersioning(ctx context.Context, p *PutVersioningParams) (*ObjectInfo, error) {
+	bucketInfo, err := n.GetBucketInfo(ctx, p.Bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	objectInfo, err := n.getSettingsObjectInfo(ctx, bucketInfo)
+	if err != nil {
+		n.log.Warn("couldn't get bucket version settings object, new one will be created",
+			zap.String("bucket_name", bucketInfo.Name),
+			zap.Stringer("cid", bucketInfo.CID),
+			zap.Error(err))
+	}
+
+	attributes := make([]*object.Attribute, 0, 3)
+
+	filename := object.NewAttribute()
+	filename.SetKey(objectSystemAttributeName)
+	filename.SetValue(bucketInfo.SettingsObjectName())
+
+	createdAt := object.NewAttribute()
+	createdAt.SetKey(object.AttributeTimestamp)
+	createdAt.SetValue(strconv.FormatInt(time.Now().UTC().Unix(), 10))
+
+	versioningIgnore := object.NewAttribute()
+	versioningIgnore.SetKey(attrVersionsIgnore)
+	versioningIgnore.SetValue(strconv.FormatBool(true))
+
+	settingsVersioningEnabled := object.NewAttribute()
+	settingsVersioningEnabled.SetKey(attrSettingsVersioningEnabled)
+	settingsVersioningEnabled.SetValue(strconv.FormatBool(p.Settings.VersioningEnabled))
+
+	attributes = append(attributes, filename, createdAt, versioningIgnore, settingsVersioningEnabled)
+
+	raw := object.NewRaw()
+	raw.SetOwnerID(bucketInfo.Owner)
+	raw.SetContainerID(bucketInfo.CID)
+	raw.SetAttributes(attributes...)
+
+	ops := new(client.PutObjectParams).WithObject(raw.Object())
+	oid, err := n.pool.PutObject(ctx, ops, n.BearerOpt(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := n.objectHead(ctx, bucketInfo.CID, oid)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = n.systemCache.Put(bucketInfo.SettingsObjectKey(), meta); err != nil {
+		n.log.Error("couldn't cache system object", zap.Error(err))
+	}
+
+	if objectInfo != nil {
+		if err = n.objectDelete(ctx, bucketInfo.CID, objectInfo.ID()); err != nil {
+			return nil, err
+		}
+	}
+
+	return objectInfoFromMeta(bucketInfo, meta, "", ""), nil
+}
+
+func (n *layer) GetBucketVersioning(ctx context.Context, bucketName string) (*BucketSettings, error) {
+	bktInfo, err := n.GetBucketInfo(ctx, bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	return n.getBucketSettings(ctx, bktInfo)
+}
+
+func (n *layer) ListObjectVersions(ctx context.Context, p *ListObjectVersionsParams) (*ListObjectVersionsInfo, error) {
+	var versions map[string]*objectVersions
+	res := &ListObjectVersionsInfo{}
+
+	bkt, err := n.GetBucketInfo(ctx, p.Bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey, err := createKey(ctx, bkt.CID, listVersionsMethod, p.Prefix, p.Delimiter)
+	if err != nil {
+		return nil, err
+	}
+
+	allObjects := n.listsCache.Get(cacheKey)
+	if allObjects == nil {
+		versions, err = n.getAllObjectsVersions(ctx, bkt, p.Prefix, p.Delimiter)
+		if err != nil {
+			return nil, err
+		}
+
+		sortedNames := make([]string, 0, len(versions))
+		for k := range versions {
+			sortedNames = append(sortedNames, k)
+		}
+		sort.Strings(sortedNames)
+
+		allObjects = make([]*ObjectInfo, 0, p.MaxKeys)
+		for _, name := range sortedNames {
+			allObjects = append(allObjects, versions[name].getFiltered()...)
+		}
+
+		// putting to cache a copy of allObjects because allObjects can be modified further
+		n.listsCache.Put(cacheKey, append([]*ObjectInfo(nil), allObjects...))
+	}
+
+	for i, obj := range allObjects {
+		if obj.Name >= p.KeyMarker && obj.Version() >= p.VersionIDMarker {
+			allObjects = allObjects[i:]
+			break
+		}
+	}
+
+	res.CommonPrefixes, allObjects = triageObjects(allObjects)
+
+	if len(allObjects) > p.MaxKeys {
+		res.IsTruncated = true
+		res.NextKeyMarker = allObjects[p.MaxKeys].Name
+		res.NextVersionIDMarker = allObjects[p.MaxKeys].Version()
+
+		allObjects = allObjects[:p.MaxKeys]
+		res.KeyMarker = allObjects[p.MaxKeys-1].Name
+		res.VersionIDMarker = allObjects[p.MaxKeys-1].Version()
+	}
+
+	objects := make([]*ObjectVersionInfo, len(allObjects))
+	for i, obj := range allObjects {
+		objects[i] = &ObjectVersionInfo{Object: obj}
+		if i == len(allObjects)-1 || allObjects[i+1].Name != obj.Name {
+			objects[i].IsLatest = true
+		}
+	}
+
+	res.Version, res.DeleteMarker = triageVersions(objects)
+	return res, nil
+}
+
+func triageVersions(objVersions []*ObjectVersionInfo) ([]*ObjectVersionInfo, []*ObjectVersionInfo) {
+	if len(objVersions) == 0 {
+		return nil, nil
+	}
+
+	var resVersion []*ObjectVersionInfo
+	var resDelMarkVersions []*ObjectVersionInfo
+
+	for _, version := range objVersions {
+		if version.Object.Headers[versionsDeleteMarkAttr] == delMarkFullObject {
+			resDelMarkVersions = append(resDelMarkVersions, version)
+		} else {
+			resVersion = append(resVersion, version)
+		}
+	}
+
+	return resVersion, resDelMarkVersions
+}
+
+func less(ov1, ov2 *ObjectInfo) bool {
+	if ov1.CreationEpoch == ov2.CreationEpoch {
+		return ov1.Version() < ov2.Version()
+	}
+	return ov1.CreationEpoch < ov2.CreationEpoch
+}
+
+func contains(list []string, elem string) bool {
+	for _, item := range list {
+		if elem == item {
+			return true
+		}
+	}
+	return false
+}
+
+func (n *layer) getBucketSettings(ctx context.Context, bktInfo *cache.BucketInfo) (*BucketSettings, error) {
+	objInfo, err := n.getSettingsObjectInfo(ctx, bktInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return objectInfoToBucketSettings(objInfo), nil
+}
+
+func objectInfoToBucketSettings(info *ObjectInfo) *BucketSettings {
+	res := &BucketSettings{}
+
+	enabled, ok := info.Headers[attrSettingsVersioningEnabled]
+	if ok {
+		if parsed, err := strconv.ParseBool(enabled); err == nil {
+			res.VersioningEnabled = parsed
+		}
+	}
+	return res
+}
+
+func (n *layer) checkVersionsExist(ctx context.Context, bkt *cache.BucketInfo, obj *VersionedObject) (*object.ID, error) {
+	id := object.NewID()
+	if err := id.Parse(obj.VersionID); err != nil {
+		return nil, errors.GetAPIError(errors.ErrInvalidVersion)
+	}
+
+	versions, err := n.headVersions(ctx, bkt, obj.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !contains(getExistedVersions(versions), obj.VersionID) {
+		return nil, errors.GetAPIError(errors.ErrInvalidVersion)
+	}
+
+	return id, nil
+}

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -1,0 +1,608 @@
+package layer
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-api-go/pkg/session"
+	"github.com/nspcc-dev/neofs-api-go/pkg/token"
+	"github.com/nspcc-dev/neofs-s3-gw/api"
+	"github.com/nspcc-dev/neofs-s3-gw/creds/accessbox"
+	"github.com/nspcc-dev/neofs-sdk-go/pkg/logger"
+	"github.com/nspcc-dev/neofs-sdk-go/pkg/pool"
+	"github.com/stretchr/testify/require"
+)
+
+type testPool struct {
+	objects      map[string]*object.Object
+	containers   map[string]*container.Container
+	currentEpoch uint64
+}
+
+func newTestPool() *testPool {
+	return &testPool{
+		objects:    make(map[string]*object.Object),
+		containers: make(map[string]*container.Container),
+	}
+}
+
+func (t *testPool) PutObject(ctx context.Context, params *client.PutObjectParams, option ...client.CallOption) (*object.ID, error) {
+	b := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return nil, err
+	}
+
+	oid := object.NewID()
+	oid.SetSHA256(sha256.Sum256(b))
+
+	raw := object.NewRawFrom(params.Object())
+	raw.SetID(oid)
+	raw.SetCreationEpoch(t.currentEpoch)
+	t.currentEpoch++
+
+	if params.PayloadReader() != nil {
+		all, err := io.ReadAll(params.PayloadReader())
+		if err != nil {
+			return nil, err
+		}
+		raw.SetPayload(all)
+	}
+
+	addr := object.NewAddress()
+	addr.SetObjectID(raw.ID())
+	addr.SetContainerID(raw.ContainerID())
+
+	t.objects[addr.String()] = raw.Object()
+	return raw.ID(), nil
+}
+
+func (t *testPool) DeleteObject(ctx context.Context, params *client.DeleteObjectParams, option ...client.CallOption) error {
+	delete(t.objects, params.Address().String())
+	return nil
+}
+
+func (t *testPool) GetObject(ctx context.Context, params *client.GetObjectParams, option ...client.CallOption) (*object.Object, error) {
+	if obj, ok := t.objects[params.Address().String()]; ok {
+		if params.PayloadWriter() != nil {
+			_, err := params.PayloadWriter().Write(obj.Payload())
+			if err != nil {
+				return nil, err
+			}
+		}
+		return obj, nil
+	}
+
+	return nil, fmt.Errorf("object not found " + params.Address().String())
+}
+
+func (t *testPool) GetObjectHeader(ctx context.Context, params *client.ObjectHeaderParams, option ...client.CallOption) (*object.Object, error) {
+	p := new(client.GetObjectParams).WithAddress(params.Address())
+	return t.GetObject(ctx, p)
+}
+
+func (t *testPool) ObjectPayloadRangeData(ctx context.Context, params *client.RangeDataParams, option ...client.CallOption) ([]byte, error) {
+	panic("implement me")
+}
+
+func (t *testPool) ObjectPayloadRangeSHA256(ctx context.Context, params *client.RangeChecksumParams, option ...client.CallOption) ([][32]byte, error) {
+	panic("implement me")
+}
+
+func (t *testPool) ObjectPayloadRangeTZ(ctx context.Context, params *client.RangeChecksumParams, option ...client.CallOption) ([][64]byte, error) {
+	panic("implement me")
+}
+
+func (t *testPool) SearchObject(ctx context.Context, params *client.SearchObjectParams, option ...client.CallOption) ([]*object.ID, error) {
+	cidStr := params.ContainerID().String()
+
+	var res []*object.ID
+
+	if len(params.SearchFilters()) == 1 {
+		for k, v := range t.objects {
+			if strings.Contains(k, cidStr) {
+				res = append(res, v.ID())
+			}
+		}
+		return res, nil
+	}
+
+	filter := params.SearchFilters()[1]
+	if len(params.SearchFilters()) != 2 || filter.Operation() != object.MatchStringEqual ||
+		(filter.Header() != object.AttributeFileName && filter.Header() != objectSystemAttributeName) {
+		return nil, fmt.Errorf("usupported filters")
+	}
+
+	for k, v := range t.objects {
+		if strings.Contains(k, cidStr) && isMatched(v.Attributes(), filter) {
+			res = append(res, v.ID())
+		}
+	}
+
+	return res, nil
+}
+
+func isMatched(attributes []*object.Attribute, filter object.SearchFilter) bool {
+	for _, attr := range attributes {
+		if attr.Key() == filter.Header() && attr.Value() == filter.Value() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *testPool) PutContainer(ctx context.Context, container *container.Container, option ...client.CallOption) (*cid.ID, error) {
+	b := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return nil, err
+	}
+
+	id := cid.New()
+	id.SetSHA256(sha256.Sum256(b))
+	t.containers[id.String()] = container
+
+	return id, nil
+}
+
+func (t *testPool) GetContainer(ctx context.Context, id *cid.ID, option ...client.CallOption) (*container.Container, error) {
+	for k, v := range t.containers {
+		if k == id.String() {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("container not found " + id.String())
+}
+
+func (t *testPool) ListContainers(ctx context.Context, id *owner.ID, option ...client.CallOption) ([]*cid.ID, error) {
+	var res []*cid.ID
+	for k := range t.containers {
+		cID := cid.New()
+		if err := cID.Parse(k); err != nil {
+			return nil, err
+		}
+		res = append(res, cID)
+	}
+
+	return res, nil
+}
+
+func (t *testPool) DeleteContainer(ctx context.Context, id *cid.ID, option ...client.CallOption) error {
+	delete(t.containers, id.String())
+	return nil
+}
+
+func (t *testPool) GetEACL(ctx context.Context, id *cid.ID, option ...client.CallOption) (*client.EACLWithSignature, error) {
+	panic("implement me")
+}
+
+func (t *testPool) SetEACL(ctx context.Context, table *eacl.Table, option ...client.CallOption) error {
+	panic("implement me")
+}
+
+func (t *testPool) AnnounceContainerUsedSpace(ctx context.Context, announcements []container.UsedSpaceAnnouncement, option ...client.CallOption) error {
+	panic("implement me")
+}
+
+func (t *testPool) Connection() (client.Client, *session.Token, error) {
+	panic("implement me")
+}
+
+func (t *testPool) OwnerID() *owner.ID {
+	return nil
+}
+
+func (t *testPool) WaitForContainerPresence(ctx context.Context, id *cid.ID, params *pool.ContainerPollingParams) error {
+	return nil
+}
+
+func (tc *testContext) putObject(content []byte) *ObjectInfo {
+	objInfo, err := tc.layer.PutObject(tc.ctx, &PutObjectParams{
+		Bucket: tc.bkt,
+		Object: tc.obj,
+		Size:   int64(len(content)),
+		Reader: bytes.NewReader(content),
+		Header: make(map[string]string),
+	})
+	require.NoError(tc.t, err)
+
+	return objInfo
+}
+
+func (tc *testContext) getObject(objectName, versionID string, needError bool) (*ObjectInfo, []byte) {
+	objInfo, err := tc.layer.GetObjectInfo(tc.ctx, &HeadObjectParams{
+		Bucket:    tc.bkt,
+		Object:    objectName,
+		VersionID: versionID,
+	})
+	if needError {
+		require.Error(tc.t, err)
+		return nil, nil
+	}
+	require.NoError(tc.t, err)
+
+	content := bytes.NewBuffer(nil)
+	err = tc.layer.GetObject(tc.ctx, &GetObjectParams{
+		ObjectInfo: objInfo,
+		Writer:     content,
+		VersionID:  versionID,
+	})
+	require.NoError(tc.t, err)
+
+	return objInfo, content.Bytes()
+}
+
+func (tc *testContext) deleteObject(objectName, versionID string) {
+	errs := tc.layer.DeleteObjects(tc.ctx, tc.bkt, []*VersionedObject{
+		{Name: objectName, VersionID: versionID},
+	})
+	for _, err := range errs {
+		require.NoError(tc.t, err)
+	}
+}
+
+func (tc *testContext) listObjectsV1() []*ObjectInfo {
+	res, err := tc.layer.ListObjectsV1(tc.ctx, &ListObjectsParamsV1{
+		ListObjectsParamsCommon: ListObjectsParamsCommon{
+			Bucket:  tc.bkt,
+			MaxKeys: 1000,
+		},
+	})
+	require.NoError(tc.t, err)
+	return res.Objects
+}
+
+func (tc *testContext) listObjectsV2() []*ObjectInfo {
+	res, err := tc.layer.ListObjectsV2(tc.ctx, &ListObjectsParamsV2{
+		ListObjectsParamsCommon: ListObjectsParamsCommon{
+			Bucket:  tc.bkt,
+			MaxKeys: 1000,
+		},
+	})
+	require.NoError(tc.t, err)
+	return res.Objects
+}
+
+func (tc *testContext) listVersions() *ListObjectVersionsInfo {
+	res, err := tc.layer.ListObjectVersions(tc.ctx, &ListObjectVersionsParams{
+		Bucket:  tc.bkt,
+		MaxKeys: 1000,
+	})
+	require.NoError(tc.t, err)
+	return res
+}
+
+func (tc *testContext) checkListObjects(ids ...*object.ID) {
+	objs := tc.listObjectsV1()
+	require.Equal(tc.t, len(ids), len(objs))
+	for _, id := range ids {
+		require.Contains(tc.t, ids, id)
+	}
+
+	objs = tc.listObjectsV2()
+	require.Equal(tc.t, len(ids), len(objs))
+	for _, id := range ids {
+		require.Contains(tc.t, ids, id)
+	}
+}
+
+type testContext struct {
+	t        *testing.T
+	ctx      context.Context
+	layer    Client
+	bkt      string
+	bktID    *cid.ID
+	obj      string
+	testPool *testPool
+}
+
+func prepareContext(t *testing.T) *testContext {
+	key, err := keys.NewPrivateKey()
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), api.BoxData, &accessbox.Box{
+		Gate: &accessbox.GateData{
+			BearerToken: token.NewBearerToken(),
+			GateKey:     key.PublicKey(),
+		},
+	})
+	l, err := logger.New(logger.WithTraceLevel("panic"))
+	require.NoError(t, err)
+	tp := newTestPool()
+
+	bktName := "testbucket1"
+	cnr := container.New(container.WithAttribute(container.AttributeName, bktName))
+	bktID, err := tp.PutContainer(ctx, cnr)
+	require.NoError(t, err)
+
+	return &testContext{
+		ctx:      ctx,
+		layer:    NewLayer(l, tp),
+		bkt:      bktName,
+		bktID:    bktID,
+		obj:      "obj1",
+		t:        t,
+		testPool: tp,
+	}
+}
+
+func TestSimpleVersioning(t *testing.T) {
+	tc := prepareContext(t)
+	_, err := tc.layer.PutBucketVersioning(tc.ctx, &PutVersioningParams{
+		Bucket:   tc.bkt,
+		Settings: &BucketSettings{VersioningEnabled: true},
+	})
+	require.NoError(t, err)
+
+	obj1Content1 := []byte("content obj1 v1")
+	obj1v1 := tc.putObject(obj1Content1)
+
+	obj1Content2 := []byte("content obj1 v2")
+	obj1v2 := tc.putObject(obj1Content2)
+
+	objv2, buffer2 := tc.getObject(tc.obj, "", false)
+	require.Equal(t, obj1Content2, buffer2)
+	require.Contains(t, objv2.Headers[versionsAddAttr], obj1v1.ID().String())
+
+	_, buffer1 := tc.getObject(tc.obj, obj1v1.ID().String(), false)
+	require.Equal(t, obj1Content1, buffer1)
+
+	tc.checkListObjects(obj1v2.ID())
+}
+
+func TestSimpleNoVersioning(t *testing.T) {
+	tc := prepareContext(t)
+
+	obj1Content1 := []byte("content obj1 v1")
+	obj1v1 := tc.putObject(obj1Content1)
+
+	obj1Content2 := []byte("content obj1 v2")
+	obj1v2 := tc.putObject(obj1Content2)
+
+	objv2, buffer2 := tc.getObject(tc.obj, "", false)
+	require.Equal(t, obj1Content2, buffer2)
+	require.Contains(t, objv2.Headers[versionsDelAttr], obj1v1.ID().String())
+
+	tc.getObject(tc.obj, obj1v1.ID().String(), true)
+	tc.checkListObjects(obj1v2.ID())
+}
+
+func TestVersioningDeleteObject(t *testing.T) {
+	tc := prepareContext(t)
+	_, err := tc.layer.PutBucketVersioning(tc.ctx, &PutVersioningParams{
+		Bucket:   tc.bkt,
+		Settings: &BucketSettings{VersioningEnabled: true},
+	})
+	require.NoError(t, err)
+
+	tc.putObject([]byte("content obj1 v1"))
+	tc.putObject([]byte("content obj1 v2"))
+
+	tc.deleteObject(tc.obj, "")
+	tc.getObject(tc.obj, "", true)
+
+	tc.checkListObjects()
+}
+
+func TestVersioningDeleteSpecificObjectVersion(t *testing.T) {
+	tc := prepareContext(t)
+	_, err := tc.layer.PutBucketVersioning(tc.ctx, &PutVersioningParams{
+		Bucket:   tc.bkt,
+		Settings: &BucketSettings{VersioningEnabled: true},
+	})
+	require.NoError(t, err)
+
+	tc.putObject([]byte("content obj1 v1"))
+	objV2Info := tc.putObject([]byte("content obj1 v2"))
+	objV3Content := []byte("content obj1 v3")
+	objV3Info := tc.putObject(objV3Content)
+
+	tc.deleteObject(tc.obj, objV2Info.Version())
+	tc.getObject(tc.obj, objV2Info.Version(), true)
+
+	_, buffer3 := tc.getObject(tc.obj, "", false)
+	require.Equal(t, objV3Content, buffer3)
+
+	tc.deleteObject(tc.obj, "")
+	tc.getObject(tc.obj, "", true)
+
+	for _, ver := range tc.listVersions().DeleteMarker {
+		if ver.IsLatest {
+			tc.deleteObject(tc.obj, ver.Object.Version())
+		}
+	}
+
+	resInfo, buffer := tc.getObject(tc.obj, "", false)
+	require.Equal(t, objV3Content, buffer)
+	require.Equal(t, objV3Info.Version(), resInfo.Version())
+}
+
+func TestNoVersioningDeleteObject(t *testing.T) {
+	tc := prepareContext(t)
+
+	tc.putObject([]byte("content obj1 v1"))
+	tc.putObject([]byte("content obj1 v2"))
+
+	tc.deleteObject(tc.obj, "")
+	tc.getObject(tc.obj, "", true)
+	tc.checkListObjects()
+}
+
+func TestGetLastVersion(t *testing.T) {
+	obj1 := getTestObjectInfo(1, getOID(1), "", "", "")
+	obj1V2 := getTestObjectInfo(1, getOID(2), "", "", "")
+	obj2 := getTestObjectInfo(2, getOID(2), obj1.Version(), "", "")
+	obj3 := getTestObjectInfo(3, getOID(3), joinVers(obj1, obj2), "", "*")
+	obj4 := getTestObjectInfo(4, getOID(4), joinVers(obj1, obj2), obj2.Version(), obj2.Version())
+	obj5 := getTestObjectInfo(5, getOID(5), obj1.Version(), obj1.Version(), obj1.Version())
+	obj6 := getTestObjectInfo(6, getOID(6), joinVers(obj1, obj2, obj3), obj3.Version(), obj3.Version())
+
+	for _, tc := range []struct {
+		versions *objectVersions
+		expected *ObjectInfo
+	}{
+		{
+			versions: &objectVersions{},
+			expected: nil,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj2, obj1},
+				addList: []string{obj1.Version(), obj2.Version()},
+			},
+			expected: obj2,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj2, obj1, obj3},
+				addList: []string{obj1.Version(), obj2.Version(), obj3.Version()},
+			},
+			expected: nil,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj2, obj1, obj4},
+				addList: []string{obj1.Version(), obj2.Version(), obj4.Version()},
+				delList: []string{obj2.Version()},
+			},
+			expected: obj1,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj5},
+				addList: []string{obj1.Version(), obj5.Version()},
+				delList: []string{obj1.Version()},
+			},
+			expected: nil,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj5},
+			},
+			expected: nil,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj2, obj3, obj6},
+				addList: []string{obj1.Version(), obj2.Version(), obj3.Version(), obj6.Version()},
+				delList: []string{obj3.Version()},
+			},
+			expected: obj2,
+		},
+		{
+			versions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj1V2},
+				addList: []string{obj1.Version(), obj1V2.Version()},
+			},
+			// creation epochs are equal
+			// obj1 version/oid > obj1_1 version/oid
+			expected: obj1,
+		},
+	} {
+		actualObjInfo := tc.versions.getLast()
+		require.Equal(t, tc.expected, actualObjInfo)
+	}
+}
+
+func TestAppendVersions(t *testing.T) {
+	obj1 := getTestObjectInfo(1, getOID(1), "", "", "")
+	obj2 := getTestObjectInfo(2, getOID(2), obj1.Version(), "", "")
+	obj3 := getTestObjectInfo(3, getOID(3), joinVers(obj1, obj2), "", "*")
+	obj4 := getTestObjectInfo(4, getOID(4), joinVers(obj1, obj2), obj2.Version(), obj2.Version())
+
+	for _, tc := range []struct {
+		versions         *objectVersions
+		objectToAdd      *ObjectInfo
+		expectedVersions *objectVersions
+	}{
+		{
+			versions:    &objectVersions{},
+			objectToAdd: obj1,
+			expectedVersions: &objectVersions{
+				objects: []*ObjectInfo{obj1},
+				addList: []string{obj1.Version()},
+			},
+		},
+		{
+			versions:    &objectVersions{objects: []*ObjectInfo{obj1}},
+			objectToAdd: obj2,
+			expectedVersions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj2},
+				addList: []string{obj1.Version(), obj2.Version()},
+			},
+		},
+		{
+			versions:    &objectVersions{objects: []*ObjectInfo{obj1, obj2}},
+			objectToAdd: obj3,
+			expectedVersions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj2, obj3},
+				addList: []string{obj1.Version(), obj2.Version(), obj3.Version()},
+			},
+		},
+		{
+			versions:    &objectVersions{objects: []*ObjectInfo{obj1, obj2}},
+			objectToAdd: obj4,
+			expectedVersions: &objectVersions{
+				objects: []*ObjectInfo{obj1, obj2, obj4},
+				addList: []string{obj1.Version(), obj2.Version(), obj4.Version()},
+				delList: []string{obj2.Version()},
+			},
+		},
+	} {
+		tc.versions.appendVersion(tc.objectToAdd)
+		require.Equal(t, tc.expectedVersions, tc.versions)
+	}
+}
+
+func joinVers(objs ...*ObjectInfo) string {
+	if len(objs) == 0 {
+		return ""
+	}
+
+	var versions []string
+	for _, obj := range objs {
+		versions = append(versions, obj.Version())
+	}
+
+	return strings.Join(versions, ",")
+}
+
+func getOID(id byte) *object.ID {
+	b := make([]byte, 32)
+	b[0] = id
+	oid := object.NewID()
+	oid.SetSHA256(sha256.Sum256(b))
+	return oid
+}
+
+func getTestObjectInfo(epoch uint64, oid *object.ID, addAttr, delAttr, delMarkAttr string) *ObjectInfo {
+	headers := make(map[string]string)
+	if addAttr != "" {
+		headers[versionsAddAttr] = addAttr
+	}
+	if delAttr != "" {
+		headers[versionsDelAttr] = delAttr
+	}
+	if delMarkAttr != "" {
+		headers[versionsDeleteMarkAttr] = delMarkAttr
+	}
+
+	return &ObjectInfo{
+		id:            oid,
+		CreationEpoch: epoch,
+		Headers:       headers,
+	}
+}

--- a/docs/aws_s3_compat.md
+++ b/docs/aws_s3_compat.md
@@ -226,8 +226,8 @@ See also `GetObject` and other method parameters.
 
 |    | Method              | Comments |
 |----|---------------------|----------|
-| 🔴 | GetBucketVersioning |          |
-| 🔴 | PutBucketVersioning |          |
+| 🟢 | GetBucketVersioning |          |
+| 🟢 | PutBucketVersioning |          |
 
 ## Website
 


### PR DESCRIPTION
The following tests pass now:
* s3tests_boto3.functional.test_s3:test_versioning_bucket_create_suspend 
* s3tests_boto3.functional.test_s3:test_atomic_read_1mb 
* s3tests_boto3.functional.test_s3:test_atomic_read_4mb 
* s3tests_boto3.functional.test_s3:test_atomic_read_8mb 
* s3tests_boto3.functional.test_s3:test_atomic_write_1mb 
* s3tests_boto3.functional.test_s3:test_atomic_write_4mb 
* s3tests_boto3.functional.test_s3:test_atomic_write_8mb
* s3tests_boto3.functional.test_s3:test_bucket_delete_notexist 
* s3tests_boto3.functional.test_s3:test_bucket_delete_nonempty 
* s3tests_boto3.functional.test_headers:test_object_create_bad_expect_empty 
* s3tests_boto3.functional.test_headers:test_object_create_bad_expect_none 
* s3tests_boto3.functional.test_headers:test_object_create_bad_contenttype_invalid
* s3tests_boto3.functional.test_s3:test_bucket_list_return_data

closes #122, #197 #209

Signed-off-by: Denis Kirillov <denis@nspcc.ru>