### PR TITLE
[#242] Fix versions sorting

### DIFF
--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -419,7 +419,7 @@ func containsACLHeaders(r *http.Request) bool {
 		r.Header.Get(api.AmzGrantFullControl) != "" || r.Header.Get(api.AmzGrantWrite) != ""
 }
 
-func (h *handler) getNewEAclTable(r *http.Request, objInfo *layer.ObjectInfo) (*eacl.Table, error) {
+func (h *handler) getNewEAclTable(r *http.Request, objInfo *api.ObjectInfo) (*eacl.Table, error) {
 	var newEaclTable *eacl.Table
 	objectACL, err := parseACLHeaders(r)
 	if err != nil {

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -249,7 +249,7 @@ func updateCRDT2PSetHeaders(p *PutObjectParams, versions *objectVersions, versio
 	}
 
 	if versioningEnabled {
-		if len(versions.addList) != 0 {
+		if !versions.isAddListEmpty() {
 			p.Header[versionsAddAttr] = versions.getAddHeader()
 		}
 
@@ -319,11 +319,11 @@ func (n *layer) headVersions(ctx context.Context, bkt *api.BucketInfo, objectNam
 		return nil, err
 	}
 
+	versions := newObjectVersions(objectName)
 	if len(ids) == 0 {
-		return nil, apiErrors.GetAPIError(apiErrors.ErrNoSuchKey)
+		return versions, apiErrors.GetAPIError(apiErrors.ErrNoSuchKey)
 	}
 
-	versions := newObjectVersions(objectName)
 	for _, id := range ids {
 		meta, err := n.objectHead(ctx, bkt.CID, id)
 		if err != nil {
@@ -524,16 +524,6 @@ func (n *layer) getAllObjectsVersions(ctx context.Context, bkt *api.BucketInfo, 
 	}
 
 	return versions, nil
-}
-
-func getExistedVersions(versions *objectVersions) []string {
-	var res []string
-	for _, add := range versions.addList {
-		if !contains(versions.delList, add) {
-			res = append(res, add)
-		}
-	}
-	return res
 }
 
 func splitVersions(header string) []string {

--- a/docs/s3_test_results.md
+++ b/docs/s3_test_results.md
@@ -377,34 +377,34 @@ Compatibility: 9/8/11
 
 ## Versioning
 
-Compatibility: 1/24/26
+Compatibility: 11/24/26
 
 |    | Test                                                                                        | s3-gw | aws s3 |
 |----|---------------------------------------------------------------------------------------------|-------|--------|
 | 1  | s3tests_boto3.functional.test_s3.test_versioning_bucket_create_suspend                      | ok    | ok     |
-| 2  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_read_remove                     | ERROR | ok     |
+| 2  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_read_remove                     | ok    | ok     |
 | 3  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_read_remove_head                | ERROR | ok     |
 | 4  | s3tests_boto3.functional.test_s3.test_versioning_obj_plain_null_version_removal             | ERROR | ok     |
 | 5  | s3tests_boto3.functional.test_s3.test_versioning_obj_plain_null_version_overwrite           | ERROR | ok     |
 | 6  | s3tests_boto3.functional.test_s3.test_versioning_obj_plain_null_version_overwrite_suspended | ERROR | ok     |
 | 7  | s3tests_boto3.functional.test_s3.test_versioning_obj_suspend_versions                       | ERROR | ok     |
-| 8  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_all             | ERROR | ok     |
-| 9  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_special_names   | ERROR | ok     |
+| 8  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_all             | ok    | ok     |
+| 9  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_special_names   | ok    | ok     |
 | 10 | s3tests_boto3.functional.test_s3.test_versioning_obj_create_overwrite_multipart             | ERROR | ok     |
-| 11 | s3tests_boto3.functional.test_s3.test_versioning_obj_list_marker                            | ERROR | ok     |
-| 12 | s3tests_boto3.functional.test_s3.test_versioning_copy_obj_version                           | ERROR | ok     |
-| 13 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete                        | ERROR | ok     |
-| 14 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete_with_marker            | ERROR | ok     |
+| 11 | s3tests_boto3.functional.test_s3.test_versioning_obj_list_marker                            | ok    | ok     |
+| 12 | s3tests_boto3.functional.test_s3.test_versioning_copy_obj_version                           | ok    | ok     |
+| 13 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete                        | ok    | ok     |
+| 14 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete_with_marker            | ok    | ok     |
 | 15 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete_with_marker_create     | ERROR | ok     |
 | 16 | s3tests_boto3.functional.test_s3.test_versioned_object_acl                                  | ERROR | FAIL   |
 | 17 | s3tests_boto3.functional.test_s3.test_versioned_object_acl_no_version_specified             | ERROR | FAIL   |
 | 18 | s3tests_boto3.functional.test_s3.test_versioned_concurrent_object_create_concurrent_remove  | ERROR | ok     |
 | 19 | s3tests_boto3.functional.test_s3.test_versioned_concurrent_object_create_and_remove         | ERROR | ok     |
-| 20 | s3tests_boto3.functional.test_s3.test_versioning_bucket_atomic_upload_return_version_id     | ERROR | ok     |
+| 20 | s3tests_boto3.functional.test_s3.test_versioning_bucket_atomic_upload_return_version_id     | ok    | ok     |
 | 21 | s3tests_boto3.functional.test_s3.test_versioning_bucket_multipart_upload_return_version_id  | ERROR | ok     |
 | 22 | s3tests_boto3.functional.test_s3.test_bucket_list_return_data_versioning                    | ERROR | ok     |
-| 23 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_bucket                          | ERROR | ok     |
-| 24 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_url_encoding                    | ERROR | ok     |
+| 23 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_bucket                          | ok    | ok     |
+| 24 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_url_encoding                    | ok    | ok     |
 | 25 | s3tests_boto3.functional.test_s3.test_object_copy_versioning_multipart_upload               | ERROR | ok     |
 | 26 | s3tests_boto3.functional.test_s3.test_multipart_copy_versioned                              | ERROR | ok     |
 


### PR DESCRIPTION
Test `s3tests_boto3.functional.test_s3:test_versioned_object_acl` test still fails but the reason is different: the notary absent  and  acl user `grant` format inconsistency.

closes #242 

Signed-off-by: Denis Kirillov <denis@nspcc.ru>