### PR TITLE
CHANGELOG: Add latest changes of v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This document outlines major changes between releases.
 
+## [0.18.0] - 2021-12-16
+
+### Added
+- Support for MultipartUpload (#186, #187) 
+- CORS support (#217)
+- Authmate supports setting of tokens lifetime in a more convenient format (duration) (#258)
+- Generation of a random key for `--no-sign-request` (#276)
+
+### Changed
+- Bucket name resolving mechanism from listing owner's containers to using DNS (#219)
+
+### Removed
+- Deprecated golint, replaced by revive (#272)
+
 ## 0.17.0 (24 Sep 2021)
 With this release we introduce [ceph-based](https://github.com/ceph/s3-tests) S3 compatibility results.
 
@@ -107,3 +121,5 @@ Bugs fixed:
 Please refer to [Github
 releases](https://github.com/nspcc-dev/neofs-s3-gw/releases/) for older
 releases.
+
+[0.18.0]: https://github.com/nspcc-dev/neofs-s3-gw/compare/v0.17.0...v0.18.0


### PR DESCRIPTION
Skipped:
#274 -- internal change, can be considered as a part of cors
#278 -- a part of cors
#282 -- fix of #258 which was added in this release
#287, #186 -- minor changes

Mentioned to #276 instead of #271 because the task changed and the PR gives more information than the issue.

Signed-off-by: Angira Kekteeva <kira@nspcc.ru>