### PR TITLE
[#306] Handle empty post policy

### DIFF
--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -368,7 +368,7 @@ func (h *handler) PostObject(w http.ResponseWriter, r *http.Request) {
 }
 
 func checkPostPolicy(r *http.Request, reqInfo *api.ReqInfo, metadata map[string]string) (*postPolicy, error) {
-	policy := &postPolicy{}
+	policy := &postPolicy{empty: true}
 	if policyStr := auth.MultipartFormValue(r, "policy"); policyStr != "" {
 		policyData, err := base64.StdEncoding.DecodeString(policyStr)
 		if err != nil {
@@ -380,6 +380,7 @@ func checkPostPolicy(r *http.Request, reqInfo *api.ReqInfo, metadata map[string]
 		if policy.Expiration.Before(time.Now()) {
 			return nil, fmt.Errorf("policy is expired: %w", errors.GetAPIError(errors.ErrInvalidArgument))
 		}
+		policy.empty = false
 	}
 
 	for key, v := range r.MultipartForm.Value {

--- a/api/handler/put_test.go
+++ b/api/handler/put_test.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"encoding/json"
+	"mime/multipart"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,4 +88,19 @@ func TestCustomJSONMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, expectedPolicy, policy)
+}
+
+func TestEmptyPostPolicy(t *testing.T) {
+	r := &http.Request{
+		MultipartForm: &multipart.Form{
+			Value: map[string][]string{
+				"key": {"some-key"},
+			},
+		},
+	}
+	reqInfo := &api.ReqInfo{}
+	metadata := make(map[string]string)
+
+	_, err := checkPostPolicy(r, reqInfo, metadata)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Add handling empty post policy
If this PR will be merged after https://github.com/nspcc-dev/neofs-sdk-go/pull/122 (and sdk version will be updated in s3-gw) we can update test results for:
* `test_s3.test_post_object_anonymous_request`
* `test_s3.test_post_object_set_success_code`

closes #306 

Signed-off-by: Denis Kirillov <denis@nspcc.ru>