### PR TITLE
[#318] Support x-amz-version-id in CompleteMultipartUpload

### DIFF
--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -458,6 +458,12 @@ func (h *handler) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		Key:    objInfo.Name,
 	}
 
+	if versioning, err := h.obj.GetBucketVersioning(r.Context(), reqInfo.BucketName); err != nil {
+		h.log.Warn("couldn't get bucket versioning", zap.String("bucket name", reqInfo.BucketName), zap.Error(err))
+	} else if versioning.VersioningEnabled {
+		w.Header().Set(api.AmzVersionID, objInfo.Version())
+	}
+
 	if err = api.EncodeToResponse(w, response); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}

--- a/docs/s3_test_results.md
+++ b/docs/s3_test_results.md
@@ -383,7 +383,7 @@ Compatibility: 8/6/8 out of 11
 
 ## Versioning
 
-Compatibility: 14/19/24 out of 26
+Compatibility: 15/19/24 out of 26
 
 |    | Test                                                                                        | s3-gw | minio | aws s3 |
 |----|---------------------------------------------------------------------------------------------|-------|-------|--------|
@@ -407,7 +407,7 @@ Compatibility: 14/19/24 out of 26
 | 18 | s3tests_boto3.functional.test_s3.test_versioned_concurrent_object_create_concurrent_remove  | ok    | ok    | ok     |
 | 19 | s3tests_boto3.functional.test_s3.test_versioned_concurrent_object_create_and_remove         | ok    | ok    | ok     |
 | 20 | s3tests_boto3.functional.test_s3.test_versioning_bucket_atomic_upload_return_version_id     | ok    | FAIL  | ok     |
-| 21 | s3tests_boto3.functional.test_s3.test_versioning_bucket_multipart_upload_return_version_id  | ERROR | FAIL  | ok     |
+| 21 | s3tests_boto3.functional.test_s3.test_versioning_bucket_multipart_upload_return_version_id  | ok    | FAIL  | ok     |
 | 22 | s3tests_boto3.functional.test_s3.test_bucket_list_return_data_versioning                    | ERROR | ERROR | ok     |
 | 23 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_bucket                          | ok    | ok    | ok     |
 | 24 | s3tests_boto3.functional.test_s3.test_object_copy_versioned_url_encoding                    | ok    | ok    | ok     |


### PR DESCRIPTION
Support `X-Amz-Version-Id` in `CompleteMultipartUpload` method
closes #318 

Signed-off-by: Denis Kirillov <denis@nspcc.ru>