### PR TITLE
[#308] Correct status code

### DIFF
--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -307,7 +307,8 @@ func (n *layer) SessionOpt(ctx context.Context) pool.CallOption {
 // Get NeoFS Object by refs.Address (should be used by auth.Center).
 func (n *layer) Get(ctx context.Context, address *object.Address) (*object.Object, error) {
 	ops := new(client.GetObjectParams).WithAddress(address)
-	return n.pool.GetObject(ctx, ops, n.CallOptions(ctx)...)
+	obj, err := n.pool.GetObject(ctx, ops, n.CallOptions(ctx)...)
+	return obj, n.transformNeofsError(ctx, err)
 }
 
 // GetBucketInfo returns bucket info by name.

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -107,7 +107,7 @@ func (n *layer) putSystemObjectIntoNeoFS(ctx context.Context, p *PutSystemObject
 	ops := new(client.PutObjectParams).WithObject(raw.Object()).WithPayloadReader(p.Reader)
 	oid, err := n.pool.PutObject(ctx, ops, n.CallOptions(ctx)...)
 	if err != nil {
-		return nil, err
+		return nil, n.transformNeofsError(ctx, err)
 	}
 
 	meta, err := n.objectHead(ctx, p.BktInfo.CID, oid)

--- a/docs/s3_test_results.md
+++ b/docs/s3_test_results.md
@@ -7,7 +7,7 @@ To update this file using tests result run:
 
 ## CopyObject
 
-Compatibility: 15/16/17 out of 17
+Compatibility: 16/16/17 out of 17
 
 |    | Test                                                                      | s3-gw | minio | aws s3 |
 |----|---------------------------------------------------------------------------|-------|-------|--------|
@@ -21,7 +21,7 @@ Compatibility: 15/16/17 out of 17
 | 8  | s3tests_boto3.functional.test_s3.test_object_copy_to_itself               | ok    | ok    | ok     |
 | 9  | s3tests_boto3.functional.test_s3.test_object_copy_to_itself_with_metadata | ok    | ok    | ok     |
 | 10 | s3tests_boto3.functional.test_s3.test_object_copy_diff_bucket             | ok    | ok    | ok     |
-| 11 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_bucket        | ERROR | FAIL  | ok     |
+| 11 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_bucket        | ok    | FAIL  | ok     |
 | 12 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_object_bucket | ERROR | ok    | ok     |
 | 13 | s3tests_boto3.functional.test_s3.test_object_copy_canned_acl              | ok    | ok    | ok     |
 | 14 | s3tests_boto3.functional.test_s3.test_object_copy_retaining_metadata      | ok    | ok    | ok     |
@@ -71,7 +71,7 @@ Compatibility: 27/25/29 out of 33
 
 ## PutObject
 
-Compatibility: 28/36/37 out of 64
+Compatibility: 29/36/37 out of 64
 
 |    | Test                                                                                           | s3-gw       | minio | aws s3 |
 |----|------------------------------------------------------------------------------------------------|-------------|-------|--------|
@@ -113,7 +113,7 @@ Compatibility: 28/36/37 out of 64
 | 36 | s3tests_boto3.functional.test_headers.test_object_create_bad_date_before_today_aws2            | FAIL        | ok    | ok     |
 | 37 | s3tests_boto3.functional.test_headers.test_object_create_bad_date_before_epoch_aws2            | FAIL        | FAIL  | ok     |
 | 38 | s3tests_boto3.functional.test_headers.test_object_create_bad_date_after_end_aws2               | FAIL        | ok    | ok     |
-| 39 | s3tests_boto3.functional.test_s3.test_object_anon_put                                          | FAIL        | ok    | ok     |
+| 39 | s3tests_boto3.functional.test_s3.test_object_anon_put                                          | ok          | ok    | ok     |
 | 40 | s3tests_boto3.functional.test_s3.test_object_put_authenticated                                 | ok          | ok    | ok     |
 | 41 | s3tests_boto3.functional.test_s3.test_object_raw_put_authenticated_expired                     | ok          | FAIL  | FAIL   |
 | 42 | s3tests_boto3.functional.test_s3.test_object_write_file                                        | ok          | ok    | ok     |


### PR DESCRIPTION
As I understand currently we cannot know type of neofs error so in this PR `strings.Contais(...)` is used.
This works on neofs-nodes that have [this fix](https://github.com/nspcc-dev/neofs-node/issues/1098)

Test `test_s3.test_100_continue` now has problem with bucket ACL (new rules are appended to the end of eACL table so they have no effect because above them there are denial rules)

closes #308 