### PR TITLE
[#312] Support cache control headers

### DIFF
--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -85,6 +85,13 @@ func writeHeaders(h http.Header, info *data.ObjectInfo, tagSetLength int) {
 	h.Set(api.AmzVersionID, info.ID.String())
 	h.Set(api.AmzTaggingCount, strconv.Itoa(tagSetLength))
 
+	if cacheControl := info.Headers[api.CacheControl]; cacheControl != "" {
+		h.Set(api.CacheControl, cacheControl)
+	}
+	if expires := info.Headers[api.Expires]; expires != "" {
+		h.Set(api.Expires, expires)
+	}
+
 	for key, val := range info.Headers {
 		if layer.IsSystemHeader(key) {
 			continue

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -194,6 +194,12 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 	if contentType := r.Header.Get(api.ContentType); len(contentType) > 0 {
 		metadata[api.ContentType] = contentType
 	}
+	if cacheControl := r.Header.Get(api.CacheControl); len(cacheControl) > 0 {
+		metadata[api.CacheControl] = cacheControl
+	}
+	if expires := r.Header.Get(api.Expires); len(expires) > 0 {
+		metadata[api.Expires] = expires
+	}
 
 	params := &layer.PutObjectParams{
 		Bucket: reqInfo.BucketName,

--- a/docs/s3_test_results.md
+++ b/docs/s3_test_results.md
@@ -71,7 +71,7 @@ Compatibility: 28/25/29 out of 33
 
 ## PutObject
 
-Compatibility: 29/36/37 out of 64
+Compatibility: 31/36/37 out of 64
 
 |    | Test                                                                                           | s3-gw       | minio | aws s3 |
 |----|------------------------------------------------------------------------------------------------|-------------|-------|--------|
@@ -118,8 +118,8 @@ Compatibility: 29/36/37 out of 64
 | 41 | s3tests_boto3.functional.test_s3.test_object_raw_put_authenticated_expired                     | ok          | FAIL  | FAIL   |
 | 42 | s3tests_boto3.functional.test_s3.test_object_write_file                                        | ok          | ok    | ok     |
 | 43 | s3tests_boto3.functional.test_s3.test_object_write_check_etag                                  | FAIL        | ok    | ok     |
-| 44 | s3tests_boto3.functional.test_s3.test_object_write_cache_control                               | ERROR       | ok    | ok     |
-| 45 | s3tests_boto3.functional.test_s3.test_object_write_expires                                     | ERROR       | ok    | ok     |
+| 44 | s3tests_boto3.functional.test_s3.test_object_write_cache_control                               | ok          | ok    | ok     |
+| 45 | s3tests_boto3.functional.test_s3.test_object_write_expires                                     | ok          | ok    | ok     |
 | 46 | s3tests_boto3.functional.test_s3.test_object_write_read_update_read_delete                     | ok          | ok    | ok     |
 | 47 | s3tests_boto3.functional.test_s3.test_object_set_get_metadata_none_to_good                     | ok          | ok    | ok     |
 | 48 | s3tests_boto3.functional.test_s3.test_object_set_get_metadata_none_to_empty                    | ERROR       | ok    | ok     |


### PR DESCRIPTION
Support header `Expires` and `Cache-Control`. They don't affect s3-gw action but we now can save it as neofs attributes
closes #312 