### PR TITLE
[#399] Use bearer token for system objects

### DIFF
--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -117,9 +117,9 @@ func (n *layer) putSystemObjectIntoNeoFS(ctx context.Context, p *PutSystemObject
 		prm.Attributes = append(prm.Attributes, [2]string{k, v})
 	}
 
-	id, err := n.neoFS.CreateObject(ctx, prm)
+	id, err := n.objectPut(ctx, prm)
 	if err != nil {
-		return nil, n.transformNeofsError(ctx, err)
+		return nil, err
 	}
 
 	meta, err := n.objectHead(ctx, p.BktInfo.CID, id)


### PR DESCRIPTION
Fix using bearer token for put system objects. This bug was the reason for not being able to enable bucket versioning.

Signed-off-by: Denis Kirillov <denis@nspcc.ru>