### PR TITLE
Fix ETag value

### DIFF
--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -2,6 +2,7 @@ package layer
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -260,7 +261,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Object
 		CreationEpoch: meta.CreationEpoch(),
 		Headers:       p.Header,
 		ContentType:   p.Header[api.ContentType],
-		HashSum:       payloadChecksum.String(),
+		HashSum:       hex.EncodeToString(payloadChecksum.Value()),
 	}, nil
 }
 

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -2,6 +2,7 @@ package layer
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -126,7 +127,7 @@ func objectInfoFromMeta(bkt *data.BucketInfo, meta *object.Object, prefix, delim
 		Headers:       userHeaders,
 		Owner:         meta.OwnerID(),
 		Size:          size,
-		HashSum:       payloadChecksum.String(),
+		HashSum:       hex.EncodeToString(payloadChecksum.Value()),
 	}
 }
 

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -1,6 +1,7 @@
 package layer
 
 import (
+	"encoding/hex"
 	"net/http"
 	"strconv"
 	"testing"
@@ -58,7 +59,7 @@ func newTestInfo(oid *oid.ID, bkt *data.BucketInfo, name string, isDir bool) *da
 		Created:     time.Unix(defaultTestCreated.Unix(), 0),
 		Owner:       bkt.Owner,
 		Headers:     make(map[string]string),
-		HashSum:     hashSum.String(),
+		HashSum:     hex.EncodeToString(hashSum.Value()),
 	}
 
 	if isDir {


### PR DESCRIPTION
ETag is a string with SHA256 of NeoFS object payload. Hash is taken from object header by neofs-sdk-go getter. Checksum type in neofs-sdk-go has changes `String()` output from `<hash>` to `SHA256:<hash>` in latest update.

S3 gateway should not be relied on unstable string format implementations and use raw value.

Before:
```
{                                                                              
    "ETag": "SHA256:11388ba8886676b0c3fc39e9b944e3533d5c5d14d76d715d8053bad1d73071d2"                                                                          
}
```

After:
```
{
    "ETag": "11388ba8886676b0c3fc39e9b944e3533d5c5d14d76d715d8053bad1d73071d2"
}
```