### PR TITLE
Less cache misses for empty bucket setting

### DIFF
--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -238,16 +238,14 @@ func (n *layer) GetBucketSettings(ctx context.Context, bktInfo *data.BucketInfo)
 		return settings, nil
 	}
 
+	settings := &data.BucketSettings{}
+
 	obj, err := n.getSystemObjectFromNeoFS(ctx, bktInfo, bktInfo.SettingsObjectName())
 	if err != nil {
-		if errors.IsS3Error(err, errors.ErrNoSuchKey) {
-			return &data.BucketSettings{}, nil
+		if !errors.IsS3Error(err, errors.ErrNoSuchKey) {
+			return nil, err
 		}
-		return nil, err
-	}
-
-	settings := &data.BucketSettings{}
-	if err = json.Unmarshal(obj.Payload(), settings); err != nil {
+	} else if err = json.Unmarshal(obj.Payload(), settings); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
There is a small optimization for object put upload stream into bucket with empty settings. We do not cache empty bucket settings, therefore it produces cache miss and extra search request every time. In `tree-service` it will be extra RPC to the tree service, which is better than whole search.

The downside is that we a are going to store some empty structs in the cache.

In my local test, object stream upload in such bucket became ~10% faster. I expect to see less improvement in `tree-service`.
We can discuss is it worth to use this optimization for such a corner case.

### Test

```
Before:
iterations.............: 1527  24.29636/s
After:
iterations.............: 1705  27.391307/s
```

Test suit
```js
import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
import s3 from 'k6/x/neofs/s3';

const payload = new Uint8Array(open('./go.sum', 'b'));
const bucket = "bucket"
const s3_cli = s3.connect("http://127.0.0.1:8080")

export const options = {
    stages: [
        { duration: '10s', target: 100 },
        { duration: '50s', target: 100 },
    ],
};

export default function () {
    const key = uuidv4();
    s3_cli.put(bucket, key, payload)
}
```