### PR TITLE
Do not produce object.Head request at regular object upload

### DIFF
--- a/api/layer/object_test.go
+++ b/api/layer/object_test.go
@@ -1,8 +1,10 @@
 package layer
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"io/ioutil"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
@@ -111,4 +113,22 @@ func TestTrimAfterObjectID(t *testing.T) {
 		actual := trimAfterObjectID("", objects)
 		require.Nil(t, actual)
 	})
+}
+
+func TestWrapReader(t *testing.T) {
+	src := make([]byte, 1024*1024+1)
+	_, err := rand.Read(src)
+	require.NoError(t, err)
+	h := sha256.Sum256(src)
+
+	streamHash := sha256.New()
+	reader := bytes.NewReader(src)
+	wrappedReader := wrapReader(reader, 64*1024, func(buf []byte) {
+		streamHash.Write(buf)
+	})
+
+	dst, err := ioutil.ReadAll(wrappedReader)
+	require.NoError(t, err)
+	require.Equal(t, src, dst)
+	require.Equal(t, h[:], streamHash.Sum(nil))
 }


### PR DESCRIPTION
Related to #441 

Hash can be calculated locally in S3 gateway. Creation epoch used for versioning and will be fetched during get and list requests. To avoid conflicts, put method do not update cache anymore.