### PR TITLE
[#416] Use tree service to list objects

### DIFF
--- a/api/cache/objectslist.go
+++ b/api/cache/objectslist.go
@@ -31,8 +31,9 @@ type (
 
 	// ObjectsListKey is a key to find a ObjectsListCache's entry.
 	ObjectsListKey struct {
-		cid    string
-		prefix string
+		cid        string
+		prefix     string
+		latestOnly bool
 	}
 )
 
@@ -93,11 +94,12 @@ func (l *ObjectsListCache) CleanCacheEntriesContainingObject(objectName string, 
 	}
 }
 
-// CreateObjectsListCacheKey returns ObjectsListKey with the given CID and prefix.
-func CreateObjectsListCacheKey(cid *cid.ID, prefix string) ObjectsListKey {
+// CreateObjectsListCacheKey returns ObjectsListKey with the given CID, prefix and latestOnly flag.
+func CreateObjectsListCacheKey(cid *cid.ID, prefix string, latestOnly bool) ObjectsListKey {
 	p := ObjectsListKey{
-		cid:    cid.String(),
-		prefix: prefix,
+		cid:        cid.String(),
+		prefix:     prefix,
+		latestOnly: latestOnly,
 	}
 
 	return p

--- a/api/handler/handlers_test.go
+++ b/api/handler/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer/neofs"
 	"github.com/nspcc-dev/neofs-s3-gw/api/resolver"
 	"github.com/nspcc-dev/neofs-s3-gw/internal/neofstest"
+	treetest "github.com/nspcc-dev/neofs-s3-gw/internal/neofstest/tree"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/stretchr/testify/require"
@@ -52,9 +53,10 @@ func prepareHandlerContext(t *testing.T) *handlerContext {
 	})
 
 	layerCfg := &layer.Config{
-		Caches:   layer.DefaultCachesConfigs(),
-		AnonKey:  layer.AnonymousKey{Key: key},
-		Resolver: testResolver,
+		Caches:      layer.DefaultCachesConfigs(),
+		AnonKey:     layer.AnonymousKey{Key: key},
+		Resolver:    testResolver,
+		TreeService: treetest.NewTreeService(),
 	}
 
 	h := &handler{

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -490,17 +490,9 @@ func (n *layer) ListObjectsV2(ctx context.Context, p *ListObjectsParamsV2) (*Lis
 }
 
 func (n *layer) listSortedObjects(ctx context.Context, p allObjectParams) ([]*data.ObjectInfo, error) {
-	versions, err := n.getAllObjectsVersions(ctx, p.Bucket, p.Prefix, p.Delimiter)
+	objects, err := n.getLatestObjectsVersions(ctx, p.Bucket, p.Prefix, p.Delimiter)
 	if err != nil {
 		return nil, err
-	}
-
-	objects := make([]*data.ObjectInfo, 0, len(versions))
-	for _, v := range versions {
-		lastVersion := v.getLast()
-		if lastVersion != nil {
-			objects = append(objects, lastVersion)
-		}
 	}
 
 	sort.Slice(objects, func(i, j int) bool {
@@ -510,10 +502,49 @@ func (n *layer) listSortedObjects(ctx context.Context, p allObjectParams) ([]*da
 	return objects, nil
 }
 
+func (n *layer) getLatestObjectsVersions(ctx context.Context, bkt *data.BucketInfo, prefix, delimiter string) ([]*data.ObjectInfo, error) {
+	var err error
+
+	cacheKey := cache.CreateObjectsListCacheKey(bkt.CID, prefix, true)
+	ids := n.listsCache.Get(cacheKey)
+
+	if ids == nil {
+		ids, err = n.treeService.GetLatestVersionsByPrefix(ctx, bkt.CID, prefix)
+		if err != nil {
+			return nil, err
+		}
+		if err := n.listsCache.Put(cacheKey, ids); err != nil {
+			n.log.Error("couldn't cache list of objects", zap.Error(err))
+		}
+	}
+
+	objectsMap := make(map[string]*data.ObjectInfo, len(ids)) // to squash the same directories
+	for i := 0; i < len(ids); i++ {
+		obj := n.objectFromObjectsCacheOrNeoFS(ctx, bkt.CID, &ids[i])
+		if obj == nil {
+			continue
+		}
+		if oi := objectInfoFromMeta(bkt, obj, prefix, delimiter); oi != nil {
+			if isSystem(oi) {
+				continue
+			}
+
+			objectsMap[oi.Name] = oi
+		}
+	}
+
+	objects := make([]*data.ObjectInfo, 0, len(objectsMap))
+	for _, obj := range objectsMap {
+		objects = append(objects, obj)
+	}
+
+	return objects, nil
+}
+
 func (n *layer) getAllObjectsVersions(ctx context.Context, bkt *data.BucketInfo, prefix, delimiter string) (map[string]*objectVersions, error) {
 	var err error
 
-	cacheKey := cache.CreateObjectsListCacheKey(bkt.CID, prefix)
+	cacheKey := cache.CreateObjectsListCacheKey(bkt.CID, prefix, false)
 	ids := n.listsCache.Get(cacheKey)
 
 	if ids == nil {

--- a/api/layer/tree_service.go
+++ b/api/layer/tree_service.go
@@ -32,6 +32,7 @@ type TreeService interface {
 
 	GetVersions(ctx context.Context, cnrID *cid.ID, objectName string) ([]*NodeVersion, error)
 	GetLatestVersion(ctx context.Context, cnrID *cid.ID, objectName string) (*NodeVersion, error)
+	GetLatestVersionsByPrefix(ctx context.Context, cnrID *cid.ID, prefix string) ([]oid.ID, error)
 	GetUnversioned(ctx context.Context, cnrID *cid.ID, objectName string) (*NodeVersion, error)
 	AddVersion(ctx context.Context, cnrID *cid.ID, objectName string, newVersion *NodeVersion) error
 	RemoveVersion(ctx context.Context, cnrID *cid.ID, nodeID uint64) error

--- a/internal/neofs/tree.go
+++ b/internal/neofs/tree.go
@@ -60,8 +60,6 @@ const (
 	maxGetSubTreeDepth = 10 // current limit on storage node side
 )
 
-var emptyOID oid.ID
-
 // NewTreeClient creates instance of TreeClient using provided address and create grpc connection.
 func NewTreeClient(addr string, key *keys.PrivateKey) (*TreeClient, error) {
 	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -308,6 +306,8 @@ func (c *TreeClient) getSubTreeLatestVersions(ctx context.Context, cnrID *cid.ID
 	if err != nil {
 		return nil, err
 	}
+
+	var emptyOID oid.ID
 
 	latestVersions := make(map[string]*TreeNode, len(subTree))
 	for _, node := range subTree {

--- a/internal/neofstest/tree/tree_mock.go
+++ b/internal/neofstest/tree/tree_mock.go
@@ -1,0 +1,157 @@
+package tree
+
+import (
+	"context"
+	"sort"
+
+	"github.com/nspcc-dev/neofs-s3-gw/api/data"
+	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+)
+
+type TreeServiceMock struct {
+	settings map[string]*data.BucketSettings
+	versions map[string]map[string][]*layer.NodeVersion
+	system   map[string]map[string]*layer.BaseNodeVersion
+}
+
+func NewTreeService() *TreeServiceMock {
+	return &TreeServiceMock{
+		settings: make(map[string]*data.BucketSettings),
+		versions: make(map[string]map[string][]*layer.NodeVersion),
+		system:   make(map[string]map[string]*layer.BaseNodeVersion),
+	}
+}
+
+func (t *TreeServiceMock) PutSettingsNode(_ context.Context, id *cid.ID, settings *data.BucketSettings) error {
+	t.settings[id.String()] = settings
+	return nil
+}
+
+func (t *TreeServiceMock) GetSettingsNode(_ context.Context, id *cid.ID) (*data.BucketSettings, error) {
+	settings, ok := t.settings[id.String()]
+	if !ok {
+		return nil, layer.ErrNodeNotFound
+	}
+
+	return settings, nil
+}
+
+func (t *TreeServiceMock) GetNotificationConfigurationNode(ctx context.Context, cnrID *cid.ID) (*oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) PutNotificationConfigurationNode(ctx context.Context, cnrID *cid.ID, objID *oid.ID) (*oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) GetBucketCORS(ctx context.Context, cnrID *cid.ID) (*oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) PutBucketCORS(ctx context.Context, cnrID *cid.ID, objID *oid.ID) (*oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) DeleteBucketCORS(ctx context.Context, cnrID *cid.ID) (*oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) GetVersions(ctx context.Context, cnrID *cid.ID, objectName string) ([]*layer.NodeVersion, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) GetLatestVersion(ctx context.Context, cnrID *cid.ID, objectName string) (*layer.NodeVersion, error) {
+	cnrVersionsMap, ok := t.versions[cnrID.String()]
+	if !ok {
+		return nil, layer.ErrNodeNotFound
+	}
+
+	versions, ok := cnrVersionsMap[objectName]
+	if !ok {
+		return nil, layer.ErrNodeNotFound
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].ID < versions[j].ID
+	})
+
+	if len(versions) != 0 {
+		return versions[len(versions)-1], nil
+	}
+
+	return nil, layer.ErrNodeNotFound
+}
+
+func (t *TreeServiceMock) GetLatestVersionsByPrefix(ctx context.Context, cnrID *cid.ID, prefix string) ([]oid.ID, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) GetUnversioned(ctx context.Context, cnrID *cid.ID, objectName string) (*layer.NodeVersion, error) {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) AddVersion(_ context.Context, cnrID *cid.ID, objectName string, newVersion *layer.NodeVersion) error {
+	cnrVersionsMap, ok := t.versions[cnrID.String()]
+	if !ok {
+		t.versions[cnrID.String()] = map[string][]*layer.NodeVersion{
+			objectName: {newVersion},
+		}
+		return nil
+	}
+
+	versions, ok := cnrVersionsMap[objectName]
+	if !ok {
+		cnrVersionsMap[objectName] = []*layer.NodeVersion{newVersion}
+		return nil
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].ID < versions[j].ID
+	})
+
+	if len(versions) != 0 {
+		newVersion.ID = versions[len(versions)-1].ID + 1
+	}
+
+	cnrVersionsMap[objectName] = append(versions, newVersion)
+
+	return nil
+}
+
+func (t *TreeServiceMock) RemoveVersion(ctx context.Context, cnrID *cid.ID, nodeID uint64) error {
+	panic("implement me")
+}
+
+func (t *TreeServiceMock) AddSystemVersion(_ context.Context, cnrID *cid.ID, objectName string, newVersion *layer.BaseNodeVersion) error {
+	cnrSystemMap, ok := t.system[cnrID.String()]
+	if !ok {
+		t.system[cnrID.String()] = map[string]*layer.BaseNodeVersion{
+			objectName: newVersion,
+		}
+		return nil
+	}
+
+	cnrSystemMap[objectName] = newVersion
+
+	return nil
+}
+
+func (t *TreeServiceMock) GetSystemVersion(_ context.Context, cnrID *cid.ID, objectName string) (*layer.BaseNodeVersion, error) {
+	cnrSystemMap, ok := t.system[cnrID.String()]
+	if !ok {
+		return nil, layer.ErrNodeNotFound
+	}
+
+	sysVersion, ok := cnrSystemMap[objectName]
+	if !ok {
+		return nil, layer.ErrNodeNotFound
+	}
+
+	return sysVersion, nil
+}
+
+func (t *TreeServiceMock) RemoveSystemVersion(ctx context.Context, cnrID *cid.ID, nodeID uint64) error {
+	panic("implement me")
+}


### PR DESCRIPTION
closes #416

The basic list tests are passed:
```
s3tests_boto3.functional.test_s3.test_bucket_list_delimiter_alt ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_delimiter_alt ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_delimiter_prefix_underscore ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_delimiter_prefix_underscore ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_delimiter_percentage ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_delimiter_basic ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_delimiter_basic ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_delimiter_prefix ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_delimiter_prefix ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_empty ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_distinct ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_many ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_many ... ok
s3tests_boto3.functional.test_s3.test_bucket_listv2_encoding_basic ... ok
s3tests_boto3.functional.test_s3.test_bucket_list_encoding_basic ... ok
```

Signed-off-by: Denis Kirillov <denis@nspcc.ru>