### PR TITLE
Do not pass nil error to `logAndSendError`

### DIFF
--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -378,7 +378,7 @@ func (h *handler) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	token, err := getSessionTokenSetEACL(r.Context())
-	if err == nil {
+	if err != nil {
 		h.logAndSendError(w, "couldn't get eacl token", reqInfo, err)
 		return
 	}


### PR DESCRIPTION
Triggered by `s3tests_boto3.functional.test_s3.test_bucket_policy_set_condition_operator_end_with_IfExists`
