### PR TITLE
*: Refactor working with NeoFS identities

### DIFF
--- a/api/cache/accessbox.go
+++ b/api/cache/accessbox.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bluele/gcache"
 	"github.com/nspcc-dev/neofs-s3-gw/creds/accessbox"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type (
@@ -41,8 +41,8 @@ func NewAccessBoxCache(config *Config) *AccessBoxCache {
 }
 
 // Get returns a cached object.
-func (o *AccessBoxCache) Get(address *address.Address) *accessbox.Box {
-	entry, err := o.cache.Get(address.String())
+func (o *AccessBoxCache) Get(address oid.Address) *accessbox.Box {
+	entry, err := o.cache.Get(address.EncodeToString())
 	if err != nil {
 		return nil
 	}
@@ -56,6 +56,6 @@ func (o *AccessBoxCache) Get(address *address.Address) *accessbox.Box {
 }
 
 // Put stores an object to cache.
-func (o *AccessBoxCache) Put(address *address.Address, box *accessbox.Box) error {
-	return o.cache.Set(address.String(), box)
+func (o *AccessBoxCache) Put(address oid.Address, box *accessbox.Box) error {
+	return o.cache.Set(address.EncodeToString(), box)
 }

--- a/api/cache/names.go
+++ b/api/cache/names.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/bluele/gcache"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // ObjectsNameCache provides lru cache for objects.
@@ -32,23 +32,23 @@ func NewObjectsNameCache(config *Config) *ObjectsNameCache {
 	return &ObjectsNameCache{cache: gc}
 }
 
-// Get returns a cached object.
-func (o *ObjectsNameCache) Get(key string) *address.Address {
+// Get returns a cached object. Returns nil if value is missing.
+func (o *ObjectsNameCache) Get(key string) *oid.Address {
 	entry, err := o.cache.Get(key)
 	if err != nil {
 		return nil
 	}
 
-	result, ok := entry.(*address.Address)
+	result, ok := entry.(oid.Address)
 	if !ok {
 		return nil
 	}
 
-	return result
+	return &result
 }
 
 // Put puts an object to cache.
-func (o *ObjectsNameCache) Put(key string, address *address.Address) error {
+func (o *ObjectsNameCache) Put(key string, address oid.Address) error {
 	return o.cache.Set(key, address)
 }
 

--- a/api/cache/objects.go
+++ b/api/cache/objects.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bluele/gcache"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // ObjectsCache provides lru cache for objects.
@@ -32,8 +32,8 @@ func New(config *Config) *ObjectsCache {
 }
 
 // Get returns a cached object.
-func (o *ObjectsCache) Get(address *address.Address) *object.Object {
-	entry, err := o.cache.Get(address.String())
+func (o *ObjectsCache) Get(address oid.Address) *object.Object {
+	entry, err := o.cache.Get(address.EncodeToString())
 	if err != nil {
 		return nil
 	}
@@ -50,10 +50,15 @@ func (o *ObjectsCache) Get(address *address.Address) *object.Object {
 func (o *ObjectsCache) Put(obj object.Object) error {
 	cnrID, _ := obj.ContainerID()
 	objID, _ := obj.ID()
-	return o.cache.Set(cnrID.String()+"/"+objID.String(), obj)
+
+	var addr oid.Address
+	addr.SetContainer(cnrID)
+	addr.SetObject(objID)
+
+	return o.cache.Set(addr.EncodeToString(), obj)
 }
 
 // Delete deletes an object from cache.
-func (o *ObjectsCache) Delete(address *address.Address) bool {
-	return o.cache.Remove(address.String())
+func (o *ObjectsCache) Delete(address oid.Address) bool {
+	return o.cache.Remove(address.EncodeToString())
 }

--- a/api/cache/objects_test.go
+++ b/api/cache/objects_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
 )
@@ -20,9 +20,10 @@ func TestCache(t *testing.T) {
 	obj := objecttest.Object()
 	objID, _ := obj.ID()
 	cnrID, _ := obj.ContainerID()
-	addr := address.NewAddress()
-	addr.SetContainerID(cnrID)
-	addr.SetObjectID(objID)
+
+	var addr oid.Address
+	addr.SetContainer(cnrID)
+	addr.SetObject(objID)
 
 	t.Run("check get", func(t *testing.T) {
 		cache := New(getTestConfig())

--- a/api/cache/objectslist.go
+++ b/api/cache/objectslist.go
@@ -79,8 +79,8 @@ func (l *ObjectsListCache) Put(key ObjectsListKey, oids []oid.ID) error {
 }
 
 // CleanCacheEntriesContainingObject deletes entries containing specified object.
-func (l *ObjectsListCache) CleanCacheEntriesContainingObject(objectName string, cid *cid.ID) {
-	cidStr := cid.String()
+func (l *ObjectsListCache) CleanCacheEntriesContainingObject(objectName string, cnr cid.ID) {
+	cidStr := cnr.EncodeToString()
 	keys := l.cache.Keys(true)
 	for _, key := range keys {
 		k, ok := key.(ObjectsListKey)
@@ -94,9 +94,9 @@ func (l *ObjectsListCache) CleanCacheEntriesContainingObject(objectName string, 
 }
 
 // CreateObjectsListCacheKey returns ObjectsListKey with the given CID and prefix.
-func CreateObjectsListCacheKey(cid *cid.ID, prefix string) ObjectsListKey {
+func CreateObjectsListCacheKey(cnr cid.ID, prefix string) ObjectsListKey {
 	p := ObjectsListKey{
-		cid:    cid.String(),
+		cid:    cnr.EncodeToString(),
 		prefix: prefix,
 	}
 

--- a/api/data/info.go
+++ b/api/data/info.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
@@ -20,8 +19,8 @@ type (
 	// BucketInfo stores basic bucket data.
 	BucketInfo struct {
 		Name               string
-		CID                *cid.ID
-		Owner              *user.ID
+		CID                cid.ID
+		Owner              user.ID
 		Created            time.Time
 		BasicACL           uint32
 		LocationConstraint string
@@ -30,8 +29,8 @@ type (
 
 	// ObjectInfo holds S3 object data.
 	ObjectInfo struct {
-		ID    *oid.ID
-		CID   *cid.ID
+		ID    oid.ID
+		CID   cid.ID
 		IsDir bool
 
 		Bucket        string
@@ -41,7 +40,7 @@ type (
 		Created       time.Time
 		CreationEpoch uint64
 		HashSum       string
-		Owner         *user.ID
+		Owner         user.ID
 		Headers       map[string]string
 	}
 
@@ -79,7 +78,7 @@ func (b *BucketInfo) NotificationConfigurationObjectName() string {
 }
 
 // Version returns object version from ObjectInfo.
-func (o *ObjectInfo) Version() string { return o.ID.String() }
+func (o *ObjectInfo) Version() string { return o.ID.EncodeToString() }
 
 // NullableVersion returns object version from ObjectInfo.
 // Return "null" if "S3-Versions-unversioned" header is present.
@@ -94,10 +93,10 @@ func (o *ObjectInfo) NullableVersion() string {
 func (o *ObjectInfo) NiceName() string { return o.Bucket + "/" + o.Name }
 
 // Address returns object address.
-func (o *ObjectInfo) Address() *address.Address {
-	addr := address.NewAddress()
-	addr.SetContainerID(*o.CID)
-	addr.SetObjectID(*o.ID)
+func (o *ObjectInfo) Address() oid.Address {
+	var addr oid.Address
+	addr.SetContainer(o.CID)
+	addr.SetObject(o.ID)
 
 	return addr
 }

--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -217,8 +217,10 @@ func (h *handler) updateBucketACL(r *http.Request, astChild *ast, bktInfo *data.
 	}
 
 	parentAst := tableToAst(bucketACL.EACL, bktInfo.Name)
+	strCID := bucketACL.Info.CID.EncodeToString()
+
 	for _, resource := range parentAst.Resources {
-		if resource.Bucket == bucketACL.Info.CID.String() {
+		if resource.Bucket == strCID {
 			resource.Bucket = bktInfo.Name
 		}
 	}

--- a/api/handler/acl_test.go
+++ b/api/handler/acl_test.go
@@ -57,7 +57,7 @@ func TestTableToAst(t *testing.T) {
 				resourceInfo: resourceInfo{
 					Bucket:  "bucketName",
 					Object:  "objectName",
-					Version: id.String(),
+					Version: id.EncodeToString(),
 				},
 				Operations: []*astOperation{{
 					Users: []string{
@@ -775,7 +775,7 @@ func TestObjectAclToAst(t *testing.T) {
 	resInfo := &resourceInfo{
 		Bucket:  "bucketName",
 		Object:  "object",
-		Version: objID.String(),
+		Version: objID.EncodeToString(),
 	}
 
 	var operations []*astOperation

--- a/api/handler/delete.go
+++ b/api/handler/delete.go
@@ -121,7 +121,7 @@ func (h *handler) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 			Event: EventObjectRemovedDelete,
 			ObjInfo: &data.ObjectInfo{
 				Name: reqInfo.ObjectName,
-				ID:   &objID,
+				ID:   objID,
 			},
 			BktInfo: bktInfo,
 			ReqInfo: reqInfo,

--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -82,7 +82,7 @@ func writeHeaders(h http.Header, info *data.ObjectInfo, tagSetLength int) {
 	h.Set(api.LastModified, info.Created.UTC().Format(http.TimeFormat))
 	h.Set(api.ContentLength, strconv.FormatInt(info.Size, 10))
 	h.Set(api.ETag, info.HashSum)
-	h.Set(api.AmzVersionID, info.ID.String())
+	h.Set(api.AmzVersionID, info.ID.EncodeToString())
 	h.Set(api.AmzTaggingCount, strconv.Itoa(tagSetLength))
 
 	if cacheControl := info.Headers[api.CacheControl]; cacheControl != "" {

--- a/api/handler/handlers_test.go
+++ b/api/handler/handlers_test.go
@@ -86,10 +86,10 @@ func createTestBucketWithLock(ctx context.Context, t *testing.T, h *handlerConte
 	var ownerID user.ID
 
 	bktInfo := &data.BucketInfo{
-		CID:               cnrID,
+		CID:               *cnrID,
 		Name:              bktName,
 		ObjectLockEnabled: true,
-		Owner:             &ownerID,
+		Owner:             ownerID,
 	}
 
 	sp := &layer.PutSettingsParams{

--- a/api/handler/head.go
+++ b/api/handler/head.go
@@ -89,7 +89,7 @@ func (h *handler) HeadBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(api.ContainerID, bktInfo.CID.String())
+	w.Header().Set(api.ContainerID, bktInfo.CID.EncodeToString())
 	api.WriteResponse(w, http.StatusOK, nil, api.MimeNone)
 }
 

--- a/api/handler/list.go
+++ b/api/handler/list.go
@@ -25,7 +25,7 @@ func (h *handler) ListBucketsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(list) > 0 {
-		own = *list[0].Owner
+		own = list[0].Owner
 	}
 
 	res = &ListBucketsResponse{

--- a/api/handler/locking.go
+++ b/api/handler/locking.go
@@ -162,7 +162,7 @@ func (h *handler) PutObjectLegalHoldHandler(w http.ResponseWriter, r *http.Reque
 		ps := &layer.PutSystemObjectParams{
 			BktInfo:  bktInfo,
 			ObjName:  objInfo.LegalHoldObject(),
-			Lock:     &data.ObjectLock{LegalHold: true, Objects: []oid.ID{*objInfo.ID}},
+			Lock:     &data.ObjectLock{LegalHold: true, Objects: []oid.ID{objInfo.ID}},
 			Metadata: make(map[string]string),
 		}
 		if _, err = h.obj.PutSystemObject(r.Context(), ps); err != nil {
@@ -252,7 +252,7 @@ func (h *handler) PutObjectRetentionHandler(w http.ResponseWriter, r *http.Reque
 		h.logAndSendError(w, "could not get object info", reqInfo, err)
 		return
 	}
-	lock.Objects = append(lock.Objects, *objInfo.ID)
+	lock.Objects = append(lock.Objects, objInfo.ID)
 
 	lockInfo, err := h.obj.HeadSystemObject(r.Context(), bktInfo, objInfo.RetentionObject())
 	if err != nil && !apiErrors.IsS3Error(err, apiErrors.ErrNoSuchKey) {

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -519,8 +519,10 @@ func (h *handler) getNewEAclTable(r *http.Request, bktInfo *data.BucketInfo, obj
 	}
 
 	parentAst := tableToAst(bacl.EACL, objInfo.Bucket)
+	strCID := bacl.Info.CID.EncodeToString()
+
 	for _, resource := range parentAst.Resources {
-		if resource.Bucket == bacl.Info.CID.String() {
+		if resource.Bucket == strCID {
 			resource.Bucket = objInfo.Bucket
 		}
 	}

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -348,7 +348,7 @@ func (n *layer) GetBucketInfo(ctx context.Context, name string) (*data.BucketInf
 		return nil, errors.GetAPIError(errors.ErrNoSuchBucket)
 	}
 
-	return n.containerInfo(ctx, containerID)
+	return n.containerInfo(ctx, *containerID)
 }
 
 // GetBucketACL returns bucket acl info by name.
@@ -536,7 +536,7 @@ func (n *layer) CopyObject(ctx context.Context, p *CopyObjectParams) (*data.Obje
 func (n *layer) deleteObject(ctx context.Context, bkt *data.BucketInfo, settings *data.BucketSettings, obj *VersionedObject) *VersionedObject {
 	var (
 		err error
-		ids []*oid.ID
+		ids []oid.ID
 	)
 
 	p := &PutObjectParams{
@@ -571,7 +571,7 @@ func (n *layer) deleteObject(ctx context.Context, bkt *data.BucketInfo, settings
 			obj.Error = err
 			return obj
 		}
-		ids = []*oid.ID{version.ID}
+		ids = []oid.ID{version.ID}
 		if version.Headers[VersionsDeleteMarkAttr] == DelMarkFullObject {
 			obj.DeleteMarkVersion = version.Version()
 		}
@@ -627,7 +627,7 @@ func (n *layer) CreateBucket(ctx context.Context, p *CreateBucketParams) (*data.
 		return nil, err
 	}
 
-	if p.SessionToken != nil && p.SessionToken.IssuedBy(*bktInfo.Owner) {
+	if p.SessionToken != nil && session.IssuedBy(*p.SessionToken, bktInfo.Owner) {
 		return nil, errors.GetAPIError(errors.ErrBucketAlreadyOwnedByYou)
 	}
 

--- a/api/layer/locking_test.go
+++ b/api/layer/locking_test.go
@@ -25,7 +25,7 @@ func TestObjectLockAttributes(t *testing.T) {
 		Metadata: make(map[string]string),
 		Lock: &data.ObjectLock{
 			Until:   time.Now(),
-			Objects: []oid.ID{*obj.ID},
+			Objects: []oid.ID{obj.ID},
 		},
 	})
 	require.NoError(t, err)

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -90,7 +90,7 @@ type (
 
 	ListPartsInfo struct {
 		Parts                []*Part
-		Owner                *user.ID
+		Owner                user.ID
 		NextPartNumberMarker int
 		IsTruncated          bool
 	}
@@ -106,7 +106,7 @@ type (
 		IsDir    bool
 		Key      string
 		UploadID string
-		Owner    *user.ID
+		Owner    user.ID
 		Created  time.Time
 	}
 )
@@ -599,7 +599,7 @@ func uploadInfoFromMeta(meta *object.Object, prefix, delimiter string) *UploadIn
 		IsDir:    isDir,
 		Key:      key,
 		UploadID: userHeaders[UploadIDAttributeName],
-		Owner:    meta.OwnerID(),
+		Owner:    *meta.OwnerID(),
 		Created:  creation,
 	}
 }

--- a/api/layer/object_test.go
+++ b/api/layer/object_test.go
@@ -9,22 +9,9 @@ import (
 
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
-
-func randID(t *testing.T) *oid.ID {
-	var id oid.ID
-	id.SetSHA256(randSHA256Checksum(t))
-
-	return &id
-}
-
-func randSHA256Checksum(t *testing.T) (cs [sha256.Size]byte) {
-	_, err := rand.Read(cs[:])
-	require.NoError(t, err)
-
-	return
-}
 
 func TestTrimAfterObjectName(t *testing.T) {
 	var (
@@ -79,23 +66,23 @@ func TestTrimAfterObjectName(t *testing.T) {
 func TestTrimAfterObjectID(t *testing.T) {
 	var (
 		objects     []*data.ObjectInfo
-		ids         []*oid.ID
+		ids         []oid.ID
 		numberOfIDS = 3
 	)
 
 	for i := 0; i < numberOfIDS; i++ {
-		id := randID(t)
+		id := oidtest.ID()
 		objects = append(objects, &data.ObjectInfo{ID: id})
 		ids = append(ids, id)
 	}
 
 	t.Run("existing id", func(t *testing.T) {
-		actual := trimAfterObjectID(ids[0].String(), objects)
+		actual := trimAfterObjectID(ids[0].EncodeToString(), objects)
 		require.Equal(t, objects[1:], actual)
 	})
 
 	t.Run("second to last id", func(t *testing.T) {
-		actual := trimAfterObjectID(ids[len(ids)-2].String(), objects)
+		actual := trimAfterObjectID(ids[len(ids)-2].EncodeToString(), objects)
 		require.Equal(t, objects[len(objects)-1:], actual)
 	})
 
@@ -105,7 +92,7 @@ func TestTrimAfterObjectID(t *testing.T) {
 	})
 
 	t.Run("last id", func(t *testing.T) {
-		actual := trimAfterObjectID(ids[len(ids)-1].String(), objects)
+		actual := trimAfterObjectID(ids[len(ids)-1].EncodeToString(), objects)
 		require.Empty(t, actual)
 	})
 

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -115,7 +115,7 @@ func objectInfoFromMeta(bkt *data.BucketInfo, meta *object.Object, prefix, delim
 	objID, _ := meta.ID()
 	payloadChecksum, _ := meta.PayloadChecksum()
 	return &data.ObjectInfo{
-		ID:    &objID,
+		ID:    objID,
 		CID:   bkt.CID,
 		IsDir: isDir,
 
@@ -125,7 +125,7 @@ func objectInfoFromMeta(bkt *data.BucketInfo, meta *object.Object, prefix, delim
 		CreationEpoch: meta.CreationEpoch(),
 		ContentType:   mimeType,
 		Headers:       userHeaders,
-		Owner:         meta.OwnerID(),
+		Owner:         *meta.OwnerID(),
 		Size:          size,
 		HashSum:       hex.EncodeToString(payloadChecksum.Value()),
 	}
@@ -138,7 +138,7 @@ func filenameFromObject(o *object.Object) string {
 		}
 	}
 	objID, _ := o.ID()
-	return objID.String()
+	return objID.EncodeToString()
 }
 
 // NameFromString splits name into a base file name and a directory path.

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -23,7 +23,7 @@ var (
 	defaultTestContentType   = http.DetectContentType(defaultTestPayload)
 )
 
-func newTestObject(id *oid.ID, bkt *data.BucketInfo, name string) *object.Object {
+func newTestObject(id oid.ID, bkt *data.BucketInfo, name string) *object.Object {
 	filename := object.NewAttribute()
 	filename.SetKey(object.AttributeFileName)
 	filename.SetValue(name)
@@ -37,9 +37,9 @@ func newTestObject(id *oid.ID, bkt *data.BucketInfo, name string) *object.Object
 	contentType.SetValue(defaultTestContentType)
 
 	obj := object.New()
-	obj.SetID(*id)
-	obj.SetOwnerID(bkt.Owner)
-	obj.SetContainerID(*bkt.CID)
+	obj.SetID(id)
+	obj.SetOwnerID(&bkt.Owner)
+	obj.SetContainerID(bkt.CID)
 	obj.SetPayload(defaultTestPayload)
 	obj.SetAttributes(*filename, *created, *contentType)
 	obj.SetPayloadSize(uint64(defaultTestPayloadLength))
@@ -47,10 +47,10 @@ func newTestObject(id *oid.ID, bkt *data.BucketInfo, name string) *object.Object
 	return obj
 }
 
-func newTestInfo(oid *oid.ID, bkt *data.BucketInfo, name string, isDir bool) *data.ObjectInfo {
+func newTestInfo(obj oid.ID, bkt *data.BucketInfo, name string, isDir bool) *data.ObjectInfo {
 	var hashSum checksum.Checksum
 	info := &data.ObjectInfo{
-		ID:          oid,
+		ID:          obj,
 		Name:        name,
 		Bucket:      bkt.Name,
 		CID:         bkt.CID,
@@ -79,8 +79,8 @@ func Test_objectInfoFromMeta(t *testing.T) {
 
 	bkt := &data.BucketInfo{
 		Name:    "test-container",
-		CID:     &containerID,
-		Owner:   &uid,
+		CID:     containerID,
+		Owner:   uid,
 		Created: time.Now(),
 	}
 
@@ -93,66 +93,66 @@ func Test_objectInfoFromMeta(t *testing.T) {
 	}{
 		{
 			name:   "small.jpg",
-			result: newTestInfo(&id, bkt, "small.jpg", false),
-			object: newTestObject(&id, bkt, "small.jpg"),
+			result: newTestInfo(id, bkt, "small.jpg", false),
+			object: newTestObject(id, bkt, "small.jpg"),
 		},
 		{
 			name:   "small.jpg not matched prefix",
 			prefix: "big",
 			result: nil,
-			object: newTestObject(&id, bkt, "small.jpg"),
+			object: newTestObject(id, bkt, "small.jpg"),
 		},
 		{
 			name:      "small.jpg delimiter",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "small.jpg", false),
-			object:    newTestObject(&id, bkt, "small.jpg"),
+			result:    newTestInfo(id, bkt, "small.jpg", false),
+			object:    newTestObject(id, bkt, "small.jpg"),
 		},
 		{
 			name:   "test/small.jpg",
-			result: newTestInfo(&id, bkt, "test/small.jpg", false),
-			object: newTestObject(&id, bkt, "test/small.jpg"),
+			result: newTestInfo(id, bkt, "test/small.jpg", false),
+			object: newTestObject(id, bkt, "test/small.jpg"),
 		},
 		{
 			name:      "test/small.jpg with prefix and delimiter",
 			prefix:    "test/",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "test/small.jpg", false),
-			object:    newTestObject(&id, bkt, "test/small.jpg"),
+			result:    newTestInfo(id, bkt, "test/small.jpg", false),
+			object:    newTestObject(id, bkt, "test/small.jpg"),
 		},
 		{
 			name:   "a/b/small.jpg",
 			prefix: "a",
-			result: newTestInfo(&id, bkt, "a/b/small.jpg", false),
-			object: newTestObject(&id, bkt, "a/b/small.jpg"),
+			result: newTestInfo(id, bkt, "a/b/small.jpg", false),
+			object: newTestObject(id, bkt, "a/b/small.jpg"),
 		},
 		{
 			name:      "a/b/small.jpg",
 			prefix:    "a/",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "a/b/", true),
-			object:    newTestObject(&id, bkt, "a/b/small.jpg"),
+			result:    newTestInfo(id, bkt, "a/b/", true),
+			object:    newTestObject(id, bkt, "a/b/small.jpg"),
 		},
 		{
 			name:      "a/b/c/small.jpg",
 			prefix:    "a/",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "a/b/", true),
-			object:    newTestObject(&id, bkt, "a/b/c/small.jpg"),
+			result:    newTestInfo(id, bkt, "a/b/", true),
+			object:    newTestObject(id, bkt, "a/b/c/small.jpg"),
 		},
 		{
 			name:      "a/b/c/small.jpg",
 			prefix:    "a/b/c/s",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "a/b/c/small.jpg", false),
-			object:    newTestObject(&id, bkt, "a/b/c/small.jpg"),
+			result:    newTestInfo(id, bkt, "a/b/c/small.jpg", false),
+			object:    newTestObject(id, bkt, "a/b/c/small.jpg"),
 		},
 		{
 			name:      "a/b/c/big.jpg",
 			prefix:    "a/b/",
 			delimiter: "/",
-			result:    newTestInfo(&id, bkt, "a/b/c/", true),
-			object:    newTestObject(&id, bkt, "a/b/c/big.jpg"),
+			result:    newTestInfo(id, bkt, "a/b/c/", true),
+			object:    newTestObject(id, bkt, "a/b/c/big.jpg"),
 		},
 	}
 

--- a/api/layer/versioning.go
+++ b/api/layer/versioning.go
@@ -271,10 +271,11 @@ func (v *objectVersions) getDelHeader() string {
 	return strings.Join(v.delList, ",")
 }
 
-func (v *objectVersions) getVersion(oid *oid.ID) *data.ObjectInfo {
+func (v *objectVersions) getVersion(obj oid.ID) *data.ObjectInfo {
+	strObj := obj.EncodeToString()
 	for _, version := range v.objects {
-		if version.Version() == oid.String() {
-			if contains(v.delList, oid.String()) {
+		if version.Version() == strObj {
+			if contains(v.delList, strObj) {
 				return nil
 			}
 			return version
@@ -397,7 +398,7 @@ func (n *layer) checkVersionsExist(ctx context.Context, bkt *data.BucketInfo, ob
 		if err = id.DecodeString(obj.VersionID); err != nil {
 			return nil, errors.GetAPIError(errors.ErrInvalidVersion)
 		}
-		version = versions.getVersion(&id)
+		version = versions.getVersion(id)
 	}
 
 	if version == nil {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/nspcc-dev/neo-go v0.98.2
 	github.com/nspcc-dev/neofs-api-go/v2 v2.12.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220504192402-12ea1e8d740f
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220527094135-3bbf7ee15d76
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220504192402-12ea1e8d740f h1:cMxSTUkugwaBFL7dEYirmjOEQ2p12phcpKO1Z3UhP64=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220504192402-12ea1e8d740f/go.mod h1:u567oWTnAyGXbPWMrbcN0NB5zCPF+PqkaKg+vcijcho=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220527094135-3bbf7ee15d76 h1:wa2DGnV258ek5sKE1DAOHsve1sG0KZA4OEw9e/TRQNM=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220527094135-3bbf7ee15d76/go.mod h1:u567oWTnAyGXbPWMrbcN0NB5zCPF+PqkaKg+vcijcho=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -22,7 +22,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/pool"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
@@ -348,9 +347,9 @@ func (x payloadReader) Read(p []byte) (int, error) {
 
 // ReadObject implements neofs.NeoFS interface method.
 func (x *NeoFS) ReadObject(ctx context.Context, prm neofs.PrmObjectRead) (*neofs.ObjectPart, error) {
-	var addr address.Address
-	addr.SetContainerID(prm.Container)
-	addr.SetObjectID(prm.Object)
+	var addr oid.Address
+	addr.SetContainer(prm.Container)
+	addr.SetObject(prm.Object)
 
 	var prmGet pool.PrmObjectGet
 	prmGet.SetAddress(addr)
@@ -449,9 +448,9 @@ func (x *NeoFS) ReadObject(ctx context.Context, prm neofs.PrmObjectRead) (*neofs
 
 // DeleteObject implements neofs.NeoFS interface method.
 func (x *NeoFS) DeleteObject(ctx context.Context, prm neofs.PrmObjectDelete) error {
-	var addr address.Address
-	addr.SetContainerID(prm.Container)
-	addr.SetObjectID(prm.Object)
+	var addr oid.Address
+	addr.SetContainer(prm.Container)
+	addr.SetObject(prm.Object)
 
 	var prmDelete pool.PrmObjectDelete
 	prmDelete.SetAddress(addr)
@@ -557,13 +556,10 @@ func (x *AuthmateNeoFS) CreateContainer(ctx context.Context, prm authmate.PrmCon
 }
 
 // ReadObjectPayload implements authmate.NeoFS interface method.
-func (x *AuthmateNeoFS) ReadObjectPayload(ctx context.Context, addr address.Address) ([]byte, error) {
-	cnrID, _ := addr.ContainerID()
-	objID, _ := addr.ObjectID()
-
+func (x *AuthmateNeoFS) ReadObjectPayload(ctx context.Context, addr oid.Address) ([]byte, error) {
 	res, err := x.neoFS.ReadObject(ctx, neofs.PrmObjectRead{
-		Container:   cnrID,
-		Object:      objID,
+		Container:   addr.Container(),
+		Object:      addr.Object(),
 		WithPayload: true,
 	})
 	if err != nil {


### PR DESCRIPTION
Pull latest changes from NeoFS SDK Go library. Decrease redundant and
unsafe usage of ID pointers. Use `EncodeToString` method in order to
calculate protocol strings.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/251
* closes #446