### PR TITLE
Upgrade SDK with latest `bearer` package API

### DIFF
--- a/api/handler/notifications.go
+++ b/api/handler/notifications.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
+	"github.com/nspcc-dev/neofs-sdk-go/bearer"
 	"go.uber.org/zap"
 )
 
@@ -159,8 +160,8 @@ func (h *handler) sendNotifications(ctx context.Context, p *SendNotificationPara
 	}
 
 	box, err := layer.GetBoxData(ctx)
-	if err == nil {
-		p.User = box.Gate.BearerToken.OwnerID().String()
+	if err == nil && box.Gate.BearerToken != nil {
+		p.User = bearer.ResolveIssuer(*box.Gate.BearerToken).EncodeToString()
 	}
 
 	topics := filterSubjects(conf, p.Event, p.ObjInfo.Name)

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer/neofs"
 	"github.com/nspcc-dev/neofs-s3-gw/api/resolver"
 	"github.com/nspcc-dev/neofs-s3-gw/creds/accessbox"
+	"github.com/nspcc-dev/neofs-sdk-go/bearer"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
@@ -312,9 +313,8 @@ func IsAuthenticatedRequest(ctx context.Context) bool {
 
 // Owner returns owner id from BearerToken (context) or from client owner.
 func (n *layer) Owner(ctx context.Context) user.ID {
-	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil {
-		ownerID, _ := bd.Gate.BearerToken.Issuer()
-		return ownerID
+	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil && bd.Gate.BearerToken != nil {
+		return bearer.ResolveIssuer(*bd.Gate.BearerToken)
 	}
 
 	var ownerID user.ID

--- a/authmate/authmate.go
+++ b/authmate/authmate.go
@@ -363,12 +363,17 @@ func buildBearerToken(key *keys.PrivateKey, table *eacl.Table, lifetime lifetime
 
 	var bearerToken bearer.Token
 	bearerToken.SetEACLTable(*table)
-	bearerToken.SetOwnerID(ownerID)
-	bearerToken.SetExpiration(lifetime.Exp)
-	bearerToken.SetIssuedAt(lifetime.Iat)
-	bearerToken.SetNotBefore(lifetime.Iat)
+	bearerToken.ForUser(ownerID)
+	bearerToken.SetExp(lifetime.Exp)
+	bearerToken.SetIat(lifetime.Iat)
+	bearerToken.SetNbf(lifetime.Iat)
 
-	return &bearerToken, bearerToken.Sign(key.PrivateKey)
+	err := bearerToken.Sign(key.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("sign bearer token: %w", err)
+	}
+
+	return &bearerToken, nil
 }
 
 func buildBearerTokens(key *keys.PrivateKey, table *eacl.Table, lifetime lifetimeOptions, gatesKeys []*keys.PublicKey) ([]*bearer.Token, error) {

--- a/creds/accessbox/bearer_token_test.go
+++ b/creds/accessbox/bearer_token_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func assertBearerToken(t *testing.T, exp, act bearer.Token) {
+	// compare binary representations since deep equal is not guaranteed
+	require.Equal(t, exp.Marshal(), act.Marshal())
+}
+
 func Test_tokens_encrypt_decrypt(t *testing.T) {
 	var (
 		tkn  bearer.Token
@@ -35,7 +40,7 @@ func Test_tokens_encrypt_decrypt(t *testing.T) {
 	err = tkn2.Unmarshal(rawTkn2)
 	require.NoError(t, err)
 
-	require.Equal(t, tkn, tkn2)
+	assertBearerToken(t, tkn, tkn2)
 }
 
 func Test_bearer_token_in_access_box(t *testing.T) {
@@ -67,7 +72,7 @@ func Test_bearer_token_in_access_box(t *testing.T) {
 	tkns, err := box2.GetTokens(cred)
 	require.NoError(t, err)
 
-	require.Equal(t, &tkn, tkns.BearerToken)
+	assertBearerToken(t, tkn, *tkns.BearerToken)
 }
 
 func Test_session_token_in_access_box(t *testing.T) {
@@ -136,7 +141,7 @@ func Test_accessbox_multiple_keys(t *testing.T) {
 	for i, k := range privateKeys {
 		tkns, err := box.GetTokens(k)
 		require.NoError(t, err, "key #%d: %s failed", i, k)
-		require.Equal(t, *tkns.BearerToken, tkn)
+		assertBearerToken(t, tkn, *tkns.BearerToken)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/nspcc-dev/neo-go v0.98.2
 	github.com/nspcc-dev/neofs-api-go/v2 v2.12.2-0.20220530190258-c82dcf7e1610
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531064755-6cb513c97688
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220601153249-c65be6d469db
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531064755-6cb513c97688 h1:+HJiRy2l4j/ww6SWNVLamO1jru7osjBoK/0IdGxUSU0=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531064755-6cb513c97688/go.mod h1:ci0d8ppgduRvrAhZVGKj6PhuOiVpvKnlDvSlDI9hkJk=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220601153249-c65be6d469db h1:4nB5s34/rTudQ8xketNXIrvWz9yUj4r4Mv81+ftC+UU=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220601153249-c65be6d469db/go.mod h1:ci0d8ppgduRvrAhZVGKj6PhuOiVpvKnlDvSlDI9hkJk=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=


### PR DESCRIPTION
* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/259

I don't insist on merging this PR, just opened it for information and advice. 