### PR TITLE
 Remove attach of bearer token when bucket owner is not an issuer of the bearer token  

### DIFF
--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -102,6 +102,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	params := &layer.CopyObjectParams{
 		SrcObject:  info,
+		ScrBktInfo: p.BktInfo,
 		DstBktInfo: dstBktInfo,
 		DstObject:  reqInfo.ObjectName,
 		SrcSize:    info.Size,

--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -168,6 +168,7 @@ func (h *handler) GetObjectHandler(w http.ResponseWriter, r *http.Request) {
 		ObjectInfo: info,
 		Writer:     w,
 		Range:      params,
+		BucketInfo: bktInfo,
 	}
 	if err = h.obj.GetObject(r.Context(), getParams); err != nil {
 		h.logAndSendError(w, "could not get object", reqInfo, err)

--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -168,7 +168,6 @@ func (h *handler) GetObjectHandler(w http.ResponseWriter, r *http.Request) {
 		ObjectInfo: info,
 		Writer:     w,
 		Range:      params,
-		VersionID:  p.VersionID,
 	}
 	if err = h.obj.GetObject(r.Context(), getParams); err != nil {
 		h.logAndSendError(w, "could not get object", reqInfo, err)

--- a/api/handler/head.go
+++ b/api/handler/head.go
@@ -62,6 +62,7 @@ func (h *handler) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 			ObjectInfo: info,
 			Writer:     buffer,
 			Range:      getRangeToDetectContentType(info.Size),
+			BucketInfo: bktInfo,
 		}
 		if err = h.obj.GetObject(r.Context(), getParams); err != nil {
 			h.logAndSendError(w, "could not get object", reqInfo, err, zap.Stringer("oid", info.ID))

--- a/api/handler/head.go
+++ b/api/handler/head.go
@@ -62,7 +62,6 @@ func (h *handler) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 			ObjectInfo: info,
 			Writer:     buffer,
 			Range:      getRangeToDetectContentType(info.Size),
-			VersionID:  reqInfo.URL.Query().Get(api.QueryVersionID),
 		}
 		if err = h.obj.GetObject(r.Context(), getParams); err != nil {
 			h.logAndSendError(w, "could not get object", reqInfo, err, zap.Stringer("oid", info.ID))

--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -316,6 +316,7 @@ func (h *handler) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 			Key:      reqInfo.ObjectName,
 		},
 		SrcObjInfo: srcInfo,
+		SrcBktInfo: srcBktInfo,
 		PartNumber: partNumber,
 		Range:      srcRange,
 	}
@@ -380,6 +381,7 @@ func (h *handler) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		p := &layer.GetObjectParams{
 			ObjectInfo: initPart,
 			Writer:     initPartPayload,
+			BucketInfo: bktInfo,
 		}
 		if err = h.obj.GetObject(r.Context(), p); err != nil {
 			h.logAndSendError(w, "could not get multipart upload acl and/or tagging", reqInfo, err, additional...)

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -77,6 +77,7 @@ type (
 	GetObjectParams struct {
 		Range      *RangeParams
 		ObjectInfo *data.ObjectInfo
+		BucketInfo *data.BucketInfo
 		Writer     io.Writer
 	}
 
@@ -124,6 +125,7 @@ type (
 	// CopyObjectParams stores object copy request parameters.
 	CopyObjectParams struct {
 		SrcObject  *data.ObjectInfo
+		ScrBktInfo *data.BucketInfo
 		DstBktInfo *data.BucketInfo
 		DstObject  string
 		SrcSize    int64
@@ -382,6 +384,7 @@ func (n *layer) GetObject(ctx context.Context, p *GetObjectParams) error {
 	var params getParams
 
 	params.objInfo = p.ObjectInfo
+	params.bktInfo = p.BucketInfo
 
 	if p.Range != nil {
 		if p.Range.Start > p.Range.End {
@@ -517,6 +520,7 @@ func (n *layer) CopyObject(ctx context.Context, p *CopyObjectParams) (*data.Obje
 			ObjectInfo: p.SrcObject,
 			Writer:     pw,
 			Range:      p.Range,
+			BucketInfo: p.ScrBktInfo,
 		})
 
 		if err = pw.CloseWithError(err); err != nil {

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -78,7 +78,6 @@ type (
 		Range      *RangeParams
 		ObjectInfo *data.ObjectInfo
 		Writer     io.Writer
-		VersionID  string
 	}
 
 	// HeadObjectParams stores object head request parameters.
@@ -323,10 +322,12 @@ func (n *layer) Owner(ctx context.Context) user.ID {
 	return ownerID
 }
 
-func (n *layer) prepareAuthParameters(ctx context.Context, prm *neofs.PrmAuth) {
+func (n *layer) prepareAuthParameters(ctx context.Context, prm *neofs.PrmAuth, bktOwner user.ID) {
 	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil {
-		prm.BearerToken = bd.Gate.BearerToken
-		return
+		if issuer, ok := bd.Gate.BearerToken.Issuer(); ok && bktOwner.Equals(issuer) {
+			prm.BearerToken = bd.Gate.BearerToken
+			return
+		}
 	}
 
 	prm.PrivateKey = &n.anonKey.Key.PrivateKey
@@ -380,8 +381,7 @@ func (n *layer) ListBuckets(ctx context.Context) ([]*data.BucketInfo, error) {
 func (n *layer) GetObject(ctx context.Context, p *GetObjectParams) error {
 	var params getParams
 
-	params.oid = p.ObjectInfo.ID
-	params.cid = p.ObjectInfo.CID
+	params.objInfo = p.ObjectInfo
 
 	if p.Range != nil {
 		if p.Range.Start > p.Range.End {
@@ -584,7 +584,7 @@ func (n *layer) deleteObject(ctx context.Context, bkt *data.BucketInfo, settings
 	}
 
 	for _, id := range ids {
-		if err = n.objectDelete(ctx, bkt.CID, id); err != nil {
+		if err = n.objectDelete(ctx, bkt, id); err != nil {
 			obj.Error = err
 			return obj
 		}

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -51,6 +51,7 @@ type (
 	UploadCopyParams struct {
 		Info       *UploadInfoParams
 		SrcObjInfo *data.ObjectInfo
+		SrcBktInfo *data.BucketInfo
 		PartNumber int
 		Range      *RangeParams
 	}
@@ -166,6 +167,7 @@ func (n *layer) UploadPartCopy(ctx context.Context, p *UploadCopyParams) (*data.
 			ObjectInfo: p.SrcObjInfo,
 			Writer:     pw,
 			Range:      p.Range,
+			BucketInfo: p.SrcBktInfo,
 		})
 
 		if err = pw.CloseWithError(err); err != nil {
@@ -305,6 +307,8 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 		layer: n,
 		parts: parts,
 	}
+
+	r.prm.bktInfo = p.Info.Bkt
 
 	obj, err = n.PutObject(ctx, &PutObjectParams{
 		BktInfo: p.Info.Bkt,

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -35,6 +35,7 @@ type (
 		off, ln uint64
 
 		objInfo *data.ObjectInfo
+		bktInfo *data.BucketInfo
 	}
 
 	// ListObjectsParamsCommon contains common parameters for ListObjectsV1 and ListObjectsV2.
@@ -125,13 +126,7 @@ func (n *layer) initObjectPayloadReader(ctx context.Context, p getParams) (io.Re
 		PayloadRange: [2]uint64{p.off, p.ln},
 	}
 
-	// should be taken from cache
-	bktInfo, err := n.GetBucketInfo(ctx, p.objInfo.Bucket)
-	if err != nil {
-		return nil, err
-	}
-
-	n.prepareAuthParameters(ctx, &prm.PrmAuth, bktInfo.Owner)
+	n.prepareAuthParameters(ctx, &prm.PrmAuth, p.bktInfo.Owner)
 
 	res, err := n.neoFS.ReadObject(ctx, prm)
 	if err != nil {

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -50,7 +50,6 @@ func (tc *testContext) getObject(objectName, versionID string, needError bool) (
 	err = tc.layer.GetObject(tc.ctx, &GetObjectParams{
 		ObjectInfo: objInfo,
 		Writer:     content,
-		VersionID:  versionID,
 	})
 	require.NoError(tc.t, err)
 

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -50,6 +50,7 @@ func (tc *testContext) getObject(objectName, versionID string, needError bool) (
 	err = tc.layer.GetObject(tc.ctx, &GetObjectParams{
 		ObjectInfo: objInfo,
 		Writer:     content,
+		BucketInfo: tc.bktInfo,
 	})
 	require.NoError(tc.t, err)
 


### PR DESCRIPTION
The `test_object_copy_canned_acl` test still not passing because `main_wallet` creates a private container in tests and `alt_wallet` can't `get-object` from private container, even the object was put with `public-read` acl. 

I tried to make `main-wallet` create `public-read` container and the test began to pass.   

I suggest to fix the test and place it in `test_s3_neofs.py`. 

Closes #459 