### PR TITLE
Upgrade NeoFS SDK Go with changed `netmap` package

### DIFF
--- a/api/handler/api.go
+++ b/api/handler/api.go
@@ -24,7 +24,7 @@ type (
 
 	// Config contains data which handler needs to keep.
 	Config struct {
-		DefaultPolicy      *netmap.PlacementPolicy
+		DefaultPolicy      netmap.PlacementPolicy
 		DefaultMaxAge      int
 		NotificatorEnabled bool
 	}

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -623,16 +623,18 @@ func (h *handler) CreateBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	useDefaultPolicy := true
 	if createParams.LocationConstraint != "" {
 		for _, placementPolicy := range policies {
 			if placementPolicy.LocationConstraint == createParams.LocationConstraint {
 				p.Policy = placementPolicy.Policy
 				p.LocationConstraint = createParams.LocationConstraint
+				useDefaultPolicy = false
 				break
 			}
 		}
 	}
-	if p.Policy == nil {
+	if useDefaultPolicy {
 		p.Policy = h.cfg.DefaultPolicy
 	}
 

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -145,7 +145,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 
 	idCnr, err := n.neoFS.CreateContainer(ctx, PrmContainerCreate{
 		Creator:              bktInfo.Owner,
-		Policy:               *p.Policy,
+		Policy:               p.Policy,
 		Name:                 p.Name,
 		SessionToken:         p.SessionToken,
 		AdditionalAttributes: attributes,

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -136,7 +136,7 @@ type (
 	// CreateBucketParams stores bucket create request parameters.
 	CreateBucketParams struct {
 		Name               string
-		Policy             *netmap.PlacementPolicy
+		Policy             netmap.PlacementPolicy
 		EACL               *eacl.Table
 		SessionToken       *session.Container
 		LocationConstraint string

--- a/authmate/authmate.go
+++ b/authmate/authmate.go
@@ -159,7 +159,7 @@ func (a *Agent) checkContainer(ctx context.Context, opts ContainerOptions, idOwn
 
 	cnrID, err := a.neoFS.CreateContainer(ctx, prm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create container in NeoFS: %w", err)
 	}
 
 	return cnrID, nil

--- a/cmd/s3-gw/app.go
+++ b/cmd/s3-gw/app.go
@@ -20,7 +20,6 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/internal/neofs"
 	"github.com/nspcc-dev/neofs-s3-gw/internal/version"
 	"github.com/nspcc-dev/neofs-s3-gw/internal/wallet"
-	"github.com/nspcc-dev/neofs-sdk-go/policy"
 	"github.com/nspcc-dev/neofs-sdk-go/pool"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -368,7 +367,7 @@ func getHandlerOptions(v *viper.Viper, l *zap.Logger) *handler.Config {
 		policyStr = v.GetString(cfgDefaultPolicy)
 	}
 
-	if cfg.DefaultPolicy, err = policy.Parse(policyStr); err != nil {
+	if err = cfg.DefaultPolicy.DecodeString(policyStr); err != nil {
 		l.Fatal("couldn't parse container default policy",
 			zap.Error(err))
 	}

--- a/creds/accessbox/accessbox.go
+++ b/creds/accessbox/accessbox.go
@@ -28,7 +28,7 @@ type Box struct {
 // ContainerPolicy represents friendly AccessBox_ContainerPolicy.
 type ContainerPolicy struct {
 	LocationConstraint string
-	Policy             *netmap.PlacementPolicy
+	Policy             netmap.PlacementPolicy
 }
 
 // GateData represents gate tokens in AccessBox.
@@ -141,15 +141,14 @@ func (x *AccessBox) GetTokens(owner *keys.PrivateKey) (*GateData, error) {
 func (x *AccessBox) GetPlacementPolicy() ([]*ContainerPolicy, error) {
 	var result []*ContainerPolicy
 	for _, policy := range x.ContainerPolicy {
-		placementPolicy := netmap.NewPlacementPolicy()
-		if err := placementPolicy.Unmarshal(policy.Policy); err != nil {
+		var cnrPolicy ContainerPolicy
+		if err := cnrPolicy.Policy.Unmarshal(policy.Policy); err != nil {
 			return nil, err
 		}
 
-		result = append(result, &ContainerPolicy{
-			LocationConstraint: policy.LocationConstraint,
-			Policy:             placementPolicy,
-		})
+		cnrPolicy.LocationConstraint = policy.LocationConstraint
+
+		result = append(result, &cnrPolicy)
 	}
 
 	return result, nil

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/nspcc-dev/neo-go v0.98.2
 	github.com/nspcc-dev/neofs-api-go/v2 v2.12.2
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220607185339-031eac2f48f6
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220607185339-031eac2f48f6 h1:aQldkeCRphHVSmsPD+05+CwLPImuLwySJkigL3AiTu8=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220607185339-031eac2f48f6/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721 h1:5Al3dddr0SG3ONhfglTyc2GSnQS0vMmygCD00vLo/jU=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=


### PR DESCRIPTION
`PlacementPolicy` type now provides methods to work with QL-encoded
policies. System network parameters can be read using dedicated method
without iterating. Applications can work with `PlacementPolicy`
variables directly so there is no need to use pointers.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/271