### PR TITLE
Upgrade NeoFS SDK Go with another approach of container sessions

### DIFF
--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -236,11 +236,10 @@ func (h *handler) updateBucketACL(r *http.Request, astChild *ast, bktInfo *data.
 		return false, fmt.Errorf("could not translate ast to table: %w", err)
 	}
 
-	table.SetSessionToken(sessionToken)
-
 	p := &layer.PutBucketACLParams{
-		BktInfo: bktInfo,
-		EACL:    table,
+		BktInfo:      bktInfo,
+		EACL:         table,
+		SessionToken: sessionToken,
 	}
 
 	if err = h.obj.PutBucketACL(r.Context(), p); err != nil {

--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -147,11 +147,11 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 			h.logAndSendError(w, "could not get new eacl table", reqInfo, err)
 			return
 		}
-		newEaclTable.SetSessionToken(sessionTokenEACL)
 
 		p := &layer.PutBucketACLParams{
-			BktInfo: dstBktInfo,
-			EACL:    newEaclTable,
+			BktInfo:      dstBktInfo,
+			EACL:         newEaclTable,
+			SessionToken: sessionTokenEACL,
 		}
 
 		if err = h.obj.PutBucketACL(r.Context(), p); err != nil {

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -179,7 +179,3 @@ func (n *layer) setContainerEACLTable(ctx context.Context, idCnr cid.ID, table *
 func (n *layer) GetContainerEACL(ctx context.Context, idCnr cid.ID) (*eacl.Table, error) {
 	return n.neoFS.ContainerEACL(ctx, idCnr)
 }
-
-func (n *layer) deleteContainer(ctx context.Context, idCnr cid.ID, sessionToken *session.Container) error {
-	return n.neoFS.DeleteContainer(ctx, idCnr, sessionToken)
-}

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -180,12 +180,6 @@ func (n *layer) GetContainerEACL(ctx context.Context, idCnr cid.ID) (*eacl.Table
 	return n.neoFS.ContainerEACL(ctx, idCnr)
 }
 
-func (n *layer) deleteContainer(ctx context.Context, idCnr cid.ID) error {
-	var sessionToken *session.Container
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		sessionToken = boxData.Gate.SessionTokenForDelete()
-	}
-
+func (n *layer) deleteContainer(ctx context.Context, idCnr cid.ID, sessionToken *session.Container) error {
 	return n.neoFS.DeleteContainer(ctx, idCnr, sessionToken)
 }

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -147,7 +147,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 		Creator:              bktInfo.Owner,
 		Policy:               p.Policy,
 		Name:                 p.Name,
-		SessionToken:         p.SessionToken,
+		SessionToken:         p.SessionContainerCreation,
 		AdditionalAttributes: attributes,
 	})
 	if err != nil {
@@ -156,7 +156,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 
 	bktInfo.CID = *idCnr
 
-	if err = n.setContainerEACLTable(ctx, bktInfo.CID, p.EACL); err != nil {
+	if err = n.setContainerEACLTable(ctx, bktInfo.CID, p.EACL, p.SessionEACL); err != nil {
 		return nil, err
 	}
 
@@ -170,15 +170,10 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 	return bktInfo, nil
 }
 
-func (n *layer) setContainerEACLTable(ctx context.Context, idCnr cid.ID, table *eacl.Table) error {
+func (n *layer) setContainerEACLTable(ctx context.Context, idCnr cid.ID, table *eacl.Table, sessionToken *session.Container) error {
 	table.SetCID(idCnr)
 
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		table.SetSessionToken(boxData.Gate.SessionTokenForSetEACL())
-	}
-
-	return n.neoFS.SetContainerEACL(ctx, *table)
+	return n.neoFS.SetContainerEACL(ctx, *table, sessionToken)
 }
 
 func (n *layer) GetContainerEACL(ctx context.Context, idCnr cid.ID) (*eacl.Table, error) {

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -151,7 +151,8 @@ type (
 	}
 	// DeleteBucketParams stores delete bucket request parameters.
 	DeleteBucketParams struct {
-		BktInfo *data.BucketInfo
+		BktInfo      *data.BucketInfo
+		SessionToken *session.Container
 	}
 
 	// PutSystemObjectParams stores putSystemObject parameters.
@@ -658,5 +659,5 @@ func (n *layer) DeleteBucket(ctx context.Context, p *DeleteBucketParams) error {
 	}
 
 	n.bucketCache.Delete(p.BktInfo.Name)
-	return n.deleteContainer(ctx, p.BktInfo.CID)
+	return n.deleteContainer(ctx, p.BktInfo.CID, p.SessionToken)
 }

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -135,17 +135,19 @@ type (
 	}
 	// CreateBucketParams stores bucket create request parameters.
 	CreateBucketParams struct {
-		Name               string
-		Policy             netmap.PlacementPolicy
-		EACL               *eacl.Table
-		SessionToken       *session.Container
-		LocationConstraint string
-		ObjectLockEnabled  bool
+		Name                     string
+		Policy                   netmap.PlacementPolicy
+		EACL                     *eacl.Table
+		SessionContainerCreation *session.Container
+		SessionEACL              *session.Container
+		LocationConstraint       string
+		ObjectLockEnabled        bool
 	}
 	// PutBucketACLParams stores put bucket acl request parameters.
 	PutBucketACLParams struct {
-		BktInfo *data.BucketInfo
-		EACL    *eacl.Table
+		BktInfo      *data.BucketInfo
+		EACL         *eacl.Table
+		SessionToken *session.Container
 	}
 	// DeleteBucketParams stores delete bucket request parameters.
 	DeleteBucketParams struct {
@@ -368,7 +370,7 @@ func (n *layer) GetBucketACL(ctx context.Context, bktInfo *data.BucketInfo) (*Bu
 
 // PutBucketACL puts bucket acl by name.
 func (n *layer) PutBucketACL(ctx context.Context, param *PutBucketACLParams) error {
-	return n.setContainerEACLTable(ctx, param.BktInfo.CID, param.EACL)
+	return n.setContainerEACLTable(ctx, param.BktInfo.CID, param.EACL, param.SessionToken)
 }
 
 // ListBuckets returns all user containers. The name of the bucket is a container
@@ -630,7 +632,7 @@ func (n *layer) CreateBucket(ctx context.Context, p *CreateBucketParams) (*data.
 		return nil, err
 	}
 
-	if p.SessionToken != nil && session.IssuedBy(*p.SessionToken, bktInfo.Owner) {
+	if p.SessionContainerCreation != nil && session.IssuedBy(*p.SessionContainerCreation, bktInfo.Owner) {
 		return nil, errors.GetAPIError(errors.ErrBucketAlreadyOwnedByYou)
 	}
 

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -659,5 +659,5 @@ func (n *layer) DeleteBucket(ctx context.Context, p *DeleteBucketParams) error {
 	}
 
 	n.bucketCache.Delete(p.BktInfo.Name)
-	return n.deleteContainer(ctx, p.BktInfo.CID, p.SessionToken)
+	return n.neoFS.DeleteContainer(ctx, p.BktInfo.CID, p.SessionToken)
 }

--- a/api/layer/neofs.go
+++ b/api/layer/neofs.go
@@ -162,10 +162,11 @@ type NeoFS interface {
 	// prevented the containers from being listed.
 	UserContainers(context.Context, user.ID) ([]cid.ID, error)
 
-	// SetContainerEACL saves the eACL table of the container in NeoFS.
+	// SetContainerEACL saves the eACL table of the container in NeoFS. The
+	// extended ACL is modified within session if session token is not nil.
 	//
 	// It returns any error encountered which prevented the eACL from being saved.
-	SetContainerEACL(context.Context, eacl.Table) error
+	SetContainerEACL(context.Context, eacl.Table, *session.Container) error
 
 	// ContainerEACL reads the container eACL from NeoFS by the container ID.
 	//

--- a/api/layer/neofs_mock.go
+++ b/api/layer/neofs_mock.go
@@ -82,7 +82,6 @@ func (t *TestNeoFS) CreateContainer(_ context.Context, prm PrmContainerCreate) (
 	}
 
 	cnr := container.New(opts...)
-	cnr.SetSessionToken(prm.SessionToken)
 
 	if prm.Name != "" {
 		container.SetNativeName(cnr, prm.Name)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.13.1-0.20220121202836-972a071d373d
 	github.com/nspcc-dev/neo-go v0.98.2
 	github.com/nspcc-dev/neofs-api-go/v2 v2.12.2
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721 h1:5Al3dddr0SG3ONhfglTyc2GSnQS0vMmygCD00vLo/jU=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599 h1:EkwWrbzImpqtNJa8IZIsfk/EqbmPwpd0DfdenrJLSbc=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -207,8 +207,11 @@ func (x *NeoFS) ContainerEACL(ctx context.Context, id cid.ID) (*eacl.Table, erro
 func (x *NeoFS) DeleteContainer(ctx context.Context, id cid.ID, token *session.Container) error {
 	var prm pool.PrmContainerDelete
 	prm.SetContainerID(id)
-	prm.SetSessionToken(*token)
 	prm.SetWaitParams(x.await)
+
+	if token != nil {
+		prm.SetSessionToken(*token)
+	}
 
 	err := x.pool.DeleteContainer(ctx, prm)
 	if err != nil {


### PR DESCRIPTION
After recent changes in NeoFS SDK Go library session tokens aren't
embedded into `container.Container` and `eacl.Table` structures.
Instead, the operations of storing given values in NeoFS are
parameterized by elements of the corresponding type.

Add dedicated session parameters to operations of bucket and eACL
setting.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/276