### PR TITLE
[#539] Add context to errors

### DIFF
--- a/api/auth/center.go
+++ b/api/auth/center.go
@@ -178,7 +178,7 @@ func (c *center) Authenticate(r *http.Request) (*accessbox.Box, error) {
 
 	box, err := c.cli.GetBox(r.Context(), *addr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get box: %w", err)
 	}
 
 	clonedRequest := cloneRequest(r, authHdr)
@@ -220,7 +220,7 @@ func (c *center) checkFormData(r *http.Request) (*accessbox.Box, error) {
 
 	box, err := c.cli.GetBox(r.Context(), addr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get box: %w", err)
 	}
 
 	secret := box.Gate.AccessKey
@@ -340,12 +340,12 @@ func prepareForm(form *multipart.Form) error {
 			if len(v) > 0 {
 				field, err := v[0].Open()
 				if err != nil {
-					return err
+					return fmt.Errorf("file header open: %w", err)
 				}
 
 				data, err := io.ReadAll(field)
 				if err != nil {
-					return err
+					return fmt.Errorf("read field: %w", err)
 				}
 				form.Value[lowerKey] = []string{string(data)}
 			}

--- a/api/cache/objects_test.go
+++ b/api/cache/objects_test.go
@@ -7,12 +7,14 @@ import (
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func getTestConfig() *Config {
 	return &Config{
 		Size:     10,
 		Lifetime: 5 * time.Second,
+		Logger:   zap.NewExample(),
 	}
 }
 

--- a/api/cache/objectslist_test.go
+++ b/api/cache/objectslist_test.go
@@ -8,6 +8,7 @@ import (
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 const testingCacheLifetime = 5 * time.Second
@@ -17,6 +18,7 @@ func getTestObjectsListConfig() *Config {
 	return &Config{
 		Size:     testingCacheSize,
 		Lifetime: testingCacheLifetime,
+		Logger:   zap.NewExample(),
 	}
 }
 

--- a/api/handler/attributes.go
+++ b/api/handler/attributes.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -176,7 +177,7 @@ func encodeToObjectAttributesResponse(info *data.ObjectInfo, p *GetObjectAttribu
 		case objectParts:
 			parts, err := formUploadAttributes(info, p.MaxParts, p.PartNumberMarker)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("form upload attributes: %w", err)
 			}
 			if parts != nil {
 				resp.ObjectParts = parts
@@ -210,7 +211,7 @@ func formUploadAttributes(info *data.ObjectInfo, maxParts, marker int) (*ObjectP
 			}
 			size, err := strconv.Atoi(nums[1])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("parse part size: %w", err)
 			}
 			parts = append(parts, Part{PartNumber: num, Size: size})
 		}

--- a/api/handler/cors.go
+++ b/api/handler/cors.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
@@ -89,11 +91,13 @@ func (h *handler) AppendCORSHeaders(w http.ResponseWriter, r *http.Request) {
 	}
 	bktInfo, err := h.obj.GetBucketInfo(r.Context(), reqInfo.BucketName)
 	if err != nil {
+		h.log.Warn("get bucket info", zap.Error(err))
 		return
 	}
 
 	cors, err := h.obj.GetBucketCORS(r.Context(), bktInfo)
 	if err != nil {
+		h.log.Warn("get bucket cors", zap.Error(err))
 		return
 	}
 

--- a/api/handler/delete.go
+++ b/api/handler/delete.go
@@ -258,7 +258,7 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 		h.log.Error("couldn't delete objects", fields...)
 	}
 
-	if err := api.EncodeToResponse(w, response); err != nil {
+	if err = api.EncodeToResponse(w, response); err != nil {
 		h.logAndSendError(w, "could not write response", reqInfo, err, zap.Array("objects", marshaler))
 		return
 	}

--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -182,7 +182,7 @@ func (h *handler) CreateMultipartUploadHandler(w http.ResponseWriter, r *http.Re
 		UploadID: info.Headers[layer.UploadIDAttributeName],
 	}
 
-	if err := api.EncodeToResponse(w, resp); err != nil {
+	if err = api.EncodeToResponse(w, resp); err != nil {
 		h.logAndSendError(w, "could not encode InitiateMultipartUploadResponse to response", reqInfo, err, additional...)
 		return
 	}
@@ -360,7 +360,7 @@ func (h *handler) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 	)
 
 	reqBody := new(CompleteMultipartUpload)
-	if err := xml.NewDecoder(r.Body).Decode(reqBody); err != nil {
+	if err = xml.NewDecoder(r.Body).Decode(reqBody); err != nil {
 		h.logAndSendError(w, "could not read complete multipart upload xml", reqInfo,
 			errors.GetAPIError(errors.ErrMalformedXML), additional...)
 		return
@@ -599,7 +599,7 @@ func (h *handler) AbortMultipartUploadHandler(w http.ResponseWriter, r *http.Req
 		}
 	)
 
-	if err := h.obj.AbortMultipartUpload(r.Context(), p); err != nil {
+	if err = h.obj.AbortMultipartUpload(r.Context(), p); err != nil {
 		h.logAndSendError(w, "could not abort multipart upload", reqInfo, err, additional...)
 		return
 	}

--- a/api/handler/notifications.go
+++ b/api/handler/notifications.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -153,7 +154,7 @@ func (h *handler) sendNotifications(ctx context.Context, p *SendNotificationPara
 
 	conf, err := h.obj.GetBucketNotificationConfiguration(ctx, p.BktInfo)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get notification configuration: %w", err)
 	}
 	if conf.IsEmpty() {
 		return nil

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -113,7 +113,7 @@ func (p *policyCondition) UnmarshalJSON(data []byte) error {
 	)
 
 	if err := json.Unmarshal(data, &v); err != nil {
-		return err
+		return fmt.Errorf("unmarshal policy condition: %w", err)
 	}
 
 	switch v := v.(type) {
@@ -487,7 +487,7 @@ func (h *handler) getNewEAclTable(r *http.Request, bktInfo *data.BucketInfo, obj
 	var newEaclTable *eacl.Table
 	key, err := h.bearerTokenIssuerKey(r.Context())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get bearer token issuer: %w", err)
 	}
 	objectACL, err := parseACLHeaders(r.Header, key)
 	if err != nil {

--- a/api/handler/response.go
+++ b/api/handler/response.go
@@ -1,6 +1,9 @@
 package handler
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"fmt"
+)
 
 // ListBucketsResponse -- format for list buckets response.
 type ListBucketsResponse struct {
@@ -207,7 +210,7 @@ func (s StringMap) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 	for _, t := range tokens {
 		if err := e.EncodeToken(t); err != nil {
-			return err
+			return fmt.Errorf("encode token: %w", err)
 		}
 	}
 

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -2,6 +2,7 @@ package layer
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -48,7 +49,7 @@ func (n *layer) containerInfo(ctx context.Context, idCnr cid.ID) (*data.BucketIn
 		if client.IsErrContainerNotFound(err) {
 			return nil, errors.GetAPIError(errors.ErrNoSuchBucket)
 		}
-		return nil, err
+		return nil, fmt.Errorf("get neofs container: %w", err)
 	}
 
 	info.Owner = *res.OwnerID()
@@ -151,13 +152,13 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 		AdditionalAttributes: attributes,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create container: %w", err)
 	}
 
 	bktInfo.CID = *idCnr
 
 	if err = n.setContainerEACLTable(ctx, bktInfo.CID, p.EACL, p.SessionEACL); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("set container eacl: %w", err)
 	}
 
 	if err = n.bucketCache.Put(bktInfo); err != nil {

--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -24,7 +24,7 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 	)
 
 	if err := xml.NewDecoder(tee).Decode(cors); err != nil {
-		return err
+		return fmt.Errorf("xml decode cors: %w", err)
 	}
 
 	if cors.CORSRules == nil {
@@ -44,12 +44,11 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 		Size:     int64(buf.Len()),
 	}
 
-	_, err := n.putSystemObjectIntoNeoFS(ctx, s)
-	if err != nil {
-		return err
+	if _, err := n.putSystemObjectIntoNeoFS(ctx, s); err != nil {
+		return fmt.Errorf("put system object: %w", err)
 	}
 
-	if err = n.systemCache.PutCORS(systemObjectKey(p.BktInfo, s.ObjName), cors); err != nil {
+	if err := n.systemCache.PutCORS(systemObjectKey(p.BktInfo, s.ObjName), cors); err != nil {
 		n.log.Error("couldn't cache system object", zap.Error(err))
 	}
 

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -340,7 +340,7 @@ func (n *layer) prepareAuthParameters(ctx context.Context, prm *PrmAuth, bktOwne
 func (n *layer) GetBucketInfo(ctx context.Context, name string) (*data.BucketInfo, error) {
 	name, err := url.QueryUnescape(name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unescape bucket name: %w", err)
 	}
 
 	if bktInfo := n.bucketCache.Get(name); bktInfo != nil {
@@ -360,7 +360,7 @@ func (n *layer) GetBucketInfo(ctx context.Context, name string) (*data.BucketInf
 func (n *layer) GetBucketACL(ctx context.Context, bktInfo *data.BucketInfo) (*BucketACL, error) {
 	eACL, err := n.GetContainerEACL(ctx, bktInfo.CID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get container eacl: %w", err)
 	}
 
 	return &BucketACL{

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -422,8 +422,7 @@ func (n *layer) AbortMultipartUpload(ctx context.Context, p *UploadInfoParams) e
 	}
 
 	for _, info := range objects {
-		err := n.objectDelete(ctx, p.Bkt, info.ID)
-		if err != nil {
+		if err = n.objectDelete(ctx, p.Bkt, info.ID); err != nil {
 			return err
 		}
 	}

--- a/api/layer/notifications.go
+++ b/api/layer/notifications.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"fmt"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
@@ -20,7 +21,7 @@ type PutBucketNotificationConfigurationParams struct {
 func (n *layer) PutBucketNotificationConfiguration(ctx context.Context, p *PutBucketNotificationConfigurationParams) error {
 	confXML, err := xml.Marshal(p.Configuration)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal notify configuration: %w", err)
 	}
 
 	s := &PutSystemObjectParams{
@@ -68,7 +69,7 @@ func (n *layer) getNotificationConf(ctx context.Context, bkt *data.BucketInfo, s
 	conf := &data.NotificationConfiguration{}
 
 	if err = xml.Unmarshal(obj.Payload(), &conf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal notify configuration: %w", err)
 	}
 
 	if err = n.systemCache.PutNotificationConfiguration(systemObjectKey(bkt, sysName), conf); err != nil {

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -568,7 +568,7 @@ func (n *layer) getAllObjectsVersions(ctx context.Context, bkt *data.BucketInfo,
 		if err != nil {
 			return nil, err
 		}
-		if err := n.listsCache.Put(cacheKey, ids); err != nil {
+		if err = n.listsCache.Put(cacheKey, ids); err != nil {
 			n.log.Error("couldn't cache list of objects", zap.Error(err))
 		}
 	}

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -108,7 +108,7 @@ func (n *layer) putSystemObjectIntoNeoFS(ctx context.Context, p *PutSystemObject
 
 			attrs, err := n.attributesFromLock(ctx, p.Lock)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("get lock attributes: %w", err)
 			}
 
 			prm.Attributes = append(prm.Attributes, attrs...)
@@ -191,7 +191,7 @@ func (n *layer) getCORS(ctx context.Context, bkt *data.BucketInfo, sysName strin
 	cors := &data.CORSConfiguration{}
 
 	if err = xml.Unmarshal(obj.Payload(), &cors); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal cors: %w", err)
 	}
 
 	if err = n.systemCache.PutCORS(systemObjectKey(bkt, sysName), cors); err != nil {
@@ -262,7 +262,7 @@ func (n *layer) GetBucketSettings(ctx context.Context, bktInfo *data.BucketInfo)
 		}
 		settings.IsNoneStatus = true
 	} else if err = json.Unmarshal(obj.Payload(), settings); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal settings: %w", err)
 	}
 
 	if err = n.systemCache.PutSettings(systemKey, settings); err != nil {
@@ -308,7 +308,7 @@ func (n *layer) attributesFromLock(ctx context.Context, lock *data.ObjectLock) (
 	if !lock.Until.IsZero() {
 		_, exp, err := n.neoFS.TimeToEpoch(ctx, lock.Until)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("fetch time to epoch: %w", err)
 		}
 
 		attrs := [][2]string{

--- a/api/notifications/controller.go
+++ b/api/notifications/controller.go
@@ -115,12 +115,12 @@ func NewController(p *Options, l *zap.Logger) (*Controller, error) {
 
 	nc, err := nats.Connect(p.URL, ncopts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("connect to nats: %w", err)
 	}
 
 	js, err := nc.JetStream()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get jet stream: %w", err)
 	}
 
 	return &Controller{
@@ -141,7 +141,7 @@ func (c *Controller) Subscribe(ctx context.Context, topic string, handler layer.
 	c.mu.RUnlock()
 
 	if _, err := c.jsClient.AddStream(&nats.StreamConfig{Name: topic}); err != nil {
-		return err
+		return fmt.Errorf("add stream: %w", err)
 	}
 
 	if _, err := c.jsClient.ChanSubscribe(topic, ch); err != nil {

--- a/api/resolver/resolver.go
+++ b/api/resolver/resolver.go
@@ -44,9 +44,9 @@ func (r *BucketResolver) Resolve(ctx context.Context, name string) (*cid.ID, err
 		if r.next != nil {
 			return r.next.Resolve(ctx, name)
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed resolve: %w", err)
 	}
-	return cnrID, err
+	return cnrID, nil
 }
 
 func NewResolver(order []string, cfg *Config) (*BucketResolver, error) {
@@ -56,7 +56,7 @@ func NewResolver(order []string, cfg *Config) (*BucketResolver, error) {
 
 	bucketResolver, err := newResolver(order[len(order)-1], cfg, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create resolver: %w", err)
 	}
 
 	for i := len(order) - 2; i >= 0; i-- {
@@ -65,7 +65,7 @@ func NewResolver(order []string, cfg *Config) (*BucketResolver, error) {
 
 		bucketResolver, err = newResolver(resolverName, cfg, next)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("create resolver: %w", err)
 		}
 	}
 

--- a/api/response.go
+++ b/api/response.go
@@ -192,9 +192,9 @@ func EncodeToResponse(w http.ResponseWriter, response interface{}) error {
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write(xmlHeader); err != nil {
-		return err
+		return fmt.Errorf("write headers: %w", err)
 	} else if err = xml.NewEncoder(w).Encode(response); err != nil {
-		return err
+		return fmt.Errorf("encode xml response: %w", err)
 	}
 
 	return nil

--- a/authmate/session_tokens.go
+++ b/authmate/session_tokens.go
@@ -25,7 +25,7 @@ func (c *sessionTokenContext) UnmarshalJSON(data []byte) (err error) {
 	var m sessionTokenModel
 
 	if err = json.Unmarshal(data, &m); err != nil {
-		return err
+		return fmt.Errorf("unmarshal session token context: %w", err)
 	}
 
 	switch m.Verb {

--- a/cmd/authmate/main.go
+++ b/cmd/authmate/main.go
@@ -101,7 +101,7 @@ func prepare() (context.Context, *zap.Logger) {
 	}
 
 	if log, err = zapConfig.Build(); err != nil {
-		panic(err)
+		panic(fmt.Errorf("create logger: %w", err))
 	}
 
 	return ctx, log
@@ -414,14 +414,14 @@ It will be ceil rounded to the nearest amount of epoch.`,
 			signer := v4.NewSigner(sess.Config.Credentials)
 			req, err := http.NewRequest(strings.ToUpper(methodFlag), fmt.Sprintf("%s/%s/%s", endpointFlag, bucketFlag, objectFlag), nil)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create new request: %w", err)
 			}
 
 			date := time.Now().UTC()
 			req.Header.Set(api.AmzDate, date.Format("20060102T150405Z"))
 
 			if _, err = signer.Presign(req, nil, "s3", *sess.Config.Region, lifetimeFlag, date); err != nil {
-				return err
+				return fmt.Errorf("presign: %w", err)
 			}
 
 			res := &struct{ URL string }{
@@ -447,7 +447,7 @@ func parsePolicies(val string) (authmate.ContainerPolicies, error) {
 
 	var policies authmate.ContainerPolicies
 	if err = json.Unmarshal(data, &policies); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal policies: %w", err)
 	}
 	if _, ok := policies[api.DefaultLocationConstraint]; ok {
 		return nil, fmt.Errorf("config overrides %s location constraint", api.DefaultLocationConstraint)
@@ -591,11 +591,11 @@ func createNeoFS(ctx context.Context, log *zap.Logger, key *ecdsa.PrivateKey, pe
 
 	p, err := pool.NewPool(prm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create pool: %w", err)
 	}
 
 	if err = p.Dial(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("dial pool: %w", err)
 	}
 
 	return neofs.NewAuthmateNeoFS(p), nil

--- a/creds/accessbox/accessbox.go
+++ b/creds/accessbox/accessbox.go
@@ -271,7 +271,7 @@ func encrypt(owner *keys.PrivateKey, sender *keys.PublicKey, data []byte) ([]byt
 		return nil, fmt.Errorf("get chiper: %w", err)
 	}
 
-	nonce := make([]byte, enc.NonceSize(), enc.NonceSize()+len(data)+enc.Overhead())
+	nonce := make([]byte, enc.NonceSize())
 	if _, err = rand.Read(nonce); err != nil {
 		return nil, fmt.Errorf("generate random nonce: %w", err)
 	}

--- a/creds/tokens/credentials.go
+++ b/creds/tokens/credentials.go
@@ -87,16 +87,16 @@ func (c *cred) GetBox(ctx context.Context, addr oid.Address) (*accessbox.Box, er
 
 	box, err := c.getAccessBox(ctx, addr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get access box: %w", err)
 	}
 
 	cachedBox, err = box.GetBox(c.key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get box: %w", err)
 	}
 
 	if err = c.cache.Put(addr, cachedBox); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("put box into cache: %w", err)
 	}
 
 	return cachedBox, nil
@@ -111,7 +111,7 @@ func (c *cred) getAccessBox(ctx context.Context, addr oid.Address) (*accessbox.A
 	// decode access box
 	var box accessbox.AccessBox
 	if err = box.Unmarshal(data); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarhal access box: %w", err)
 	}
 
 	return &box, nil
@@ -125,7 +125,7 @@ func (c *cred) Put(ctx context.Context, idCnr cid.ID, issuer user.ID, box *acces
 	}
 	data, err := box.Marshal()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshall box: %w", err)
 	}
 
 	idObj, err := c.neoFS.CreateObject(ctx, PrmObjectCreate{
@@ -136,7 +136,7 @@ func (c *cred) Put(ctx context.Context, idCnr cid.ID, issuer user.ID, box *acces
 		Payload:         data,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create object: %w", err)
 	}
 
 	var addr oid.Address

--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -130,7 +130,7 @@ func (x *NeoFS) CreateContainer(ctx context.Context, prm layer.PrmContainerCreat
 	// environment without hh disabling feature will ignore this attribute
 	// environment with hh disabling feature will set disabling = true if network config says so
 	if hhDisabled, err := isHomomorphicHashDisabled(ctx, x.pool); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("check homomorphic hash enabled: %w", err)
 	} else if hhDisabled {
 		cnrOptions = append(cnrOptions, container.WithAttribute(
 			"__NEOFS__DISABLE_HOMOMORPHIC_HASHING", "true"))
@@ -576,7 +576,7 @@ func (x *AuthmateNeoFS) CreateObject(ctx context.Context, prm tokens.PrmObjectCr
 func isHomomorphicHashDisabled(ctx context.Context, p *pool.Pool) (bool, error) {
 	ni, err := p.NetworkInfo(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("network info: %w", err)
 	}
 
 	// FIXME(@cthulhu-rider): parameter format hasn't been fixed in the protocol yet,

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -28,7 +28,7 @@ func GetKeyFromPath(walletPath, addrStr string, password *string) (*keys.Private
 	}
 	w, err := wallet.NewWalletFromFile(walletPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse wallet: %w", err)
 	}
 
 	var addr util.Uint160


### PR DESCRIPTION
Didn't add context to some error because such errors can already be [appropriate error](https://github.com/nspcc-dev/neofs-s3-gw/blob/8a1fc8ae3f99cff5dc060d969a384e94e109ec1f/api/errors/errors.go#L15) and we have to preserve this.

I see two possible approach to manage this (add context to all errors): 

1. Add the following function and Invoke it [here](https://github.com/nspcc-dev/neofs-s3-gw/blob/8a1fc8ae3f99cff5dc060d969a384e94e109ec1f/api/response.go#L116) (to send appropriate error to user):
```
func fetchS3Error(err error) *errors.Error {
	for err != nil {
		if e, ok := err.(errors.Error); ok {
			return &e
		}
		err = stderrors.Unwrap(err)
	}
	return nil
}
```

2. Add the following function and invoke it when we want to add context:
```
func wrapError(err error, msg string) error {
	if _, ok := err.(errors.Error); ok {
		return err
	}

	return fmt.Errorf("%s: %w", msg, err)
}
```

The first approach is more CPU intensive. The second one can potentially lead to missing some important context.

close #539 
Signed-off-by: Denis Kirillov <denis@nspcc.ru>