### PR TITLE
 Fix error when file with policy cannot be read

### DIFF
--- a/cmd/s3-authmate/main.go
+++ b/cmd/s3-authmate/main.go
@@ -185,7 +185,7 @@ func issueSecret() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "bearer-rules",
-				Usage:       "rules for bearer token as plain json string",
+				Usage:       "rules for bearer token (filepath or a plain json string are allowed)",
 				Required:    false,
 				Destination: &eaclRulesFlag,
 			},
@@ -448,7 +448,7 @@ func parsePolicies(val string) (authmate.ContainerPolicies, error) {
 
 	if !json.Valid(data) {
 		if data, err = os.ReadFile(val); err != nil {
-			return nil, fmt.Errorf("coudln't read json file or its content is invalid")
+			return nil, fmt.Errorf("coudln't read json file or provided json is invalid")
 		}
 	}
 
@@ -478,7 +478,7 @@ func getJSONRules(val string) ([]byte, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("coudln't read json file or its content is invalid")
+	return nil, fmt.Errorf("coudln't read json file or provided json is invalid")
 }
 
 // getSessionRules reads json session rules.

--- a/cmd/s3-authmate/main.go
+++ b/cmd/s3-authmate/main.go
@@ -440,9 +440,16 @@ func parsePolicies(val string) (authmate.ContainerPolicies, error) {
 	if val == "" {
 		return nil, nil
 	}
-	data, err := os.ReadFile(val)
-	if err != nil {
+
+	var (
 		data = []byte(val)
+		err  error
+	)
+
+	if !json.Valid(data) {
+		if data, err = os.ReadFile(val); err != nil {
+			return nil, fmt.Errorf("coudln't read json file or its content is invalid")
+		}
 	}
 
 	var policies authmate.ContainerPolicies


### PR DESCRIPTION
I'm not sure is there a convenient way to differentiate invalid plain-string json and non-existing filepath, that's why `authmate` returns the same error for both cases. But text of the error when file cannot be read become clearer.
 
Closes #558