### PR TITLE
[#578] Unify version output

### DIFF
--- a/cmd/s3-authmate/main.go
+++ b/cmd/s3-authmate/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -109,11 +110,14 @@ func prepare() (context.Context, *zap.Logger) {
 
 func main() {
 	app := &cli.App{
-		Name:     "NeoFS gate authentication manager",
+		Name:     "NeoFS S3 Authmate",
 		Usage:    "Helps manage delegated access via gates to data stored in NeoFS network",
 		Version:  version.Version,
 		Flags:    appFlags(),
 		Commands: appCommands(),
+	}
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s\nVersion: %s\nGoVersion: %s\n", c.App.Name, c.App.Version, runtime.Version())
 	}
 
 	viper.AutomaticEnv()

--- a/cmd/s3-gw/app_settings.go
+++ b/cmd/s3-gw/app_settings.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -259,7 +260,7 @@ func newSettings() *viper.Viper {
 
 		os.Exit(0)
 	case versionFlag != nil && *versionFlag:
-		fmt.Printf("NeoFS S3 gateway %s\n", version.Version)
+		fmt.Printf("NeoFS S3 Gateway\nVersion: %s\nGoVersion: %s\n", version.Version, runtime.Version())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Output:
```
$ neofs-s3-gw --version
NeoFS S3 Gateway
Version: v0.21.1-72-gb43a4194
GoVersion: go1.17.3

$ neofs-s3-authmate --version
NeoFS S3 Authmate
Version: v0.21.1-72-gb43a4194
GoVersion: go1.17.3
```

close #578
Signed-off-by: Denis Kirillov <denis@nspcc.ru>