### PR TITLE
Do not set sticky bit in authmate container

### DIFF
--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -543,7 +543,6 @@ func (x *AuthmateNeoFS) CreateContainer(ctx context.Context, prm authmate.PrmCon
 	basicACL := acl.Private
 	// allow reading objects to OTHERS in order to provide read access to S3 gateways
 	basicACL.AllowOp(acl.OpObjectGet, acl.RoleOthers)
-	basicACL.MakeSticky()
 
 	return x.neoFS.CreateContainer(ctx, layer.PrmContainerCreate{
 		Creator:  prm.Owner,


### PR DESCRIPTION
Closes #540 

In public containers sticky bit allows to limit
ownership of the objects by request authors.

In private or public-read containers it doesn't
make any sense so sticky bit is redundant there.