### PR TITLE
Update compatibility table

### DIFF
--- a/docs/s3_test_results.md
+++ b/docs/s3_test_results.md
@@ -1,5 +1,8 @@
 # S3 compatibility test results
 
+NeoFS Node: v0.30.0
+NeoFS S3 Gateway: v0.22.0-10-g87f6681
+
 To update this file using tests result, run:
 ```sh
 ./updateTestsResult.sh ceph_tests_result.txt
@@ -7,7 +10,7 @@ To update this file using tests result, run:
 
 ## CopyObject
 
-Compatibility: 15/16/17 out of 17
+Compatibility: 14/16/17 out of 17
 
 |    | Test                                                                      | s3-gw | minio | aws s3 |
 |----|---------------------------------------------------------------------------|-------|-------|--------|
@@ -21,7 +24,7 @@ Compatibility: 15/16/17 out of 17
 | 8  | s3tests_boto3.functional.test_s3.test_object_copy_to_itself               | ok    | ok    | ok     |
 | 9  | s3tests_boto3.functional.test_s3.test_object_copy_to_itself_with_metadata | ok    | ok    | ok     |
 | 10 | s3tests_boto3.functional.test_s3.test_object_copy_diff_bucket             | ok    | ok    | ok     |
-| 11 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_bucket        | ok    | FAIL  | ok     |
+| 11 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_bucket        | FAIL  | FAIL  | ok     |
 | 12 | s3tests_boto3.functional.test_s3.test_object_copy_not_owned_object_bucket | ERROR | ok    | ok     |
 | 13 | s3tests_boto3.functional.test_s3.test_object_copy_canned_acl              | ERROR | ok    | ok     |
 | 14 | s3tests_boto3.functional.test_s3.test_object_copy_retaining_metadata      | ok    | ok    | ok     |
@@ -31,7 +34,7 @@ Compatibility: 15/16/17 out of 17
 
 ## GetObject
 
-Compatibility: 29/25/29 out of 33
+Compatibility: 27/25/29 out of 33
 
 |    | Test                                                                                     | s3-gw | minio | aws s3 |
 |----|------------------------------------------------------------------------------------------|-------|-------|--------|
@@ -56,22 +59,22 @@ Compatibility: 29/25/29 out of 33
 | 19 | s3tests_boto3.functional.test_s3.test_atomic_read_1mb                                    | ok    | ok    | ok     |
 | 20 | s3tests_boto3.functional.test_s3.test_atomic_read_4mb                                    | ok    | ok    | ok     |
 | 21 | s3tests_boto3.functional.test_s3.test_atomic_read_8mb                                    | ok    | ok    | ok     |
-| 22 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_not_expired           | FAIL  | ok    | ok     |
+| 22 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_not_expired           | ok    | ok    | ok     |
 | 23 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_out_range_zero        | ok    | ok    | ok     |
-| 24 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_out_max_range         | ok    | FAIL  | FAIL   |
+| 24 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_out_max_range         | FAIL  | FAIL  | FAIL   |
 | 25 | s3tests_boto3.functional.test_s3.test_object_raw_get_x_amz_expires_out_positive_range    | ok    | FAIL  | FAIL   |
-| 26 | s3tests_boto3.functional.test_s3.test_object_raw_get                                     | ok    | ERROR | ok     |
+| 26 | s3tests_boto3.functional.test_s3.test_object_raw_get                                     | ERROR | ERROR | ok     |
 | 27 | s3tests_boto3.functional.test_s3.test_object_raw_get_bucket_gone                         | ok    | FAIL  | ok     |
 | 28 | s3tests_boto3.functional.test_s3.test_object_delete_key_bucket_gone                      | ok    | FAIL  | ok     |
 | 29 | s3tests_boto3.functional.test_s3.test_object_header_acl_grants                           | ERROR | FAIL  | ERROR  |
-| 30 | s3tests_boto3.functional.test_s3.test_object_raw_get_object_gone                         | ok    | FAIL  | ok     |
+| 30 | s3tests_boto3.functional.test_s3.test_object_raw_get_object_gone                         | FAIL  | FAIL  | ok     |
 | 31 | s3tests_boto3.functional.test_s3.test_object_raw_get_object_acl                          | FAIL  | ok    | ok     |
 | 32 | s3tests_boto3.functional.test_s3.test_object_raw_authenticated                           | ok    | ok    | ok     |
 | 33 | s3tests_boto3.functional.test_s3.test_object_raw_response_headers                        | ok    | ok    | ok     |
 
 ## PutObject
 
-Compatibility: 31/36/37 out of 64
+Compatibility: 33/43/37 out of 64
 
 |    | Test                                                                                           | s3-gw       | minio | aws s3 |
 |----|------------------------------------------------------------------------------------------------|-------------|-------|--------|
@@ -133,8 +136,8 @@ Compatibility: 31/36/37 out of 64
 | 56 | s3tests_boto3.functional.test_s3.test_atomic_write_1mb                                         | ok          | ok    | ok     |
 | 57 | s3tests_boto3.functional.test_s3.test_atomic_write_4mb                                         | ok          | ok    | ok     |
 | 58 | s3tests_boto3.functional.test_s3.test_atomic_write_8mb                                         | ok          | ok    | ok     |
-| 59 | s3tests_boto3.functional.test_s3.test_atomic_dual_write_1mb                                    | FAIL        | ok    | ERROR  |
-| 60 | s3tests_boto3.functional.test_s3.test_atomic_dual_write_4mb                                    | FAIL        | ok    | ERROR  |
+| 59 | s3tests_boto3.functional.test_s3.test_atomic_dual_write_1mb                                    | ok          | ok    | ERROR  |
+| 60 | s3tests_boto3.functional.test_s3.test_atomic_dual_write_4mb                                    | ok          | ok    | ERROR  |
 | 61 | s3tests_boto3.functional.test_s3.test_atomic_dual_write_8mb                                    | ok          | ok    | ERROR  |
 | 62 | s3tests_boto3.functional.test_s3.test_atomic_conditional_write_1mb                             | ok          | ok    | ERROR  |
 | 63 | s3tests_boto3.functional.test_s3.test_atomic_dual_conditional_write_1mb                        | FAIL        | FAIL  | FAIL   |
@@ -183,7 +186,7 @@ This group is not explicitly supported by s3-gw, but some tests may pass.
 
 ## ListObjects
 
-Compatibility: 76/63/75 out of 84
+Compatibility: 77/63/75 out of 84
 
 |    | Test                                                                                            | s3-gw | minio | aws s3 |
 |----|-------------------------------------------------------------------------------------------------|-------|-------|--------|
@@ -264,22 +267,22 @@ Compatibility: 76/63/75 out of 84
 | 75 | s3tests_boto3.functional.test_s3.test_bucket_list_marker_after_list                             | ok    | ok    | ok     |
 | 76 | s3tests_boto3.functional.test_s3.test_bucket_listv2_startafter_after_list                       | ok    | ok    | ok     |
 | 77 | s3tests_boto3.functional.test_s3.test_bucket_list_return_data                                   | ok    | FAIL  | ok     |
-| 78 | s3tests_boto3.functional.test_s3.test_bucket_list_objects_anonymous                             | ok    | ERROR | ok     |
-| 79 | s3tests_boto3.functional.test_s3.test_bucket_listv2_objects_anonymous                           | ok    | ERROR | ok     |
-| 80 | s3tests_boto3.functional.test_s3.test_bucket_list_objects_anonymous_fail                        | ok    | ok    | ok     |
-| 81 | s3tests_boto3.functional.test_s3.test_bucket_listv2_objects_anonymous_fail                      | ok    | ok    | ok     |
+| 78 | s3tests_boto3.functional.test_s3.test_bucket_list_objects_anonymous                             | ERROR | ERROR | ok     |
+| 79 | s3tests_boto3.functional.test_s3.test_bucket_listv2_objects_anonymous                           | ERROR | ERROR | ok     |
+| 80 | s3tests_boto3.functional.test_s3.test_bucket_list_objects_anonymous_fail                        | FAIL  | ok    | ok     |
+| 81 | s3tests_boto3.functional.test_s3.test_bucket_listv2_objects_anonymous_fail                      | FAIL  | ok    | ok     |
 | 82 | s3tests_boto3.functional.test_s3.test_bucket_list_special_prefix                                | ok    | ok    | ok     |
 | 83 | s3tests_boto3.functional.test_s3.test_bucket_list_long_name                                     | ok    | ok    | ok     |
 | 84 | s3tests_boto3.functional.test_s3.test_basic_key_count                                           | ok    | ok    | ok     |
 
 ## Object ACL
 
-Compatibility:  4/3/10 out of 19
+Compatibility:  3/3/10 out of 19
 
 |    | Test                                                                                  | s3-gw | minio | aws s3 |
 |----|---------------------------------------------------------------------------------------|-------|-------|--------|
 | 1  | s3tests_boto3.functional.test_headers.test_object_acl_create_contentlength_none       | ok    | ERROR | ok     |
-| 2  | s3tests_boto3.functional.test_s3.test_object_anon_put_write_access                    | ok    | ERROR | ERROR  |
+| 2  | s3tests_boto3.functional.test_s3.test_object_anon_put_write_access                    | ERROR | ERROR | ERROR  |
 | 3  | s3tests_boto3.functional.test_s3.test_object_acl_default                              | FAIL  | FAIL  | ok     |
 | 4  | s3tests_boto3.functional.test_s3.test_object_acl_canned_during_create                 | FAIL  | FAIL  | FAIL   |
 | 5  | s3tests_boto3.functional.test_s3.test_object_acl_canned                               | FAIL  | FAIL  | FAIL   |
@@ -300,7 +303,7 @@ Compatibility:  4/3/10 out of 19
 
 ## Locking
 
-Compatibility:  12/5/29 out of 29
+Compatibility:  4/5/29 out of 29
 
 |    | Test                                                                                           | s3-gw | minio | aws s3 |
 |----|------------------------------------------------------------------------------------------------|-------|-------|--------|
@@ -308,31 +311,31 @@ Compatibility:  12/5/29 out of 29
 | 2  | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_lock_invalid_bucket                  | ok    | FAIL  | ok     |
 | 3  | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_lock_with_days_and_years             | FAIL  | ERROR | ok     |
 | 4  | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_lock_invalid_days                    | FAIL  | ERROR | FAIL   |
-| 5  | s3tests_boto3.functional.test_s3.test_object_lock_uploading_obj                                | ok    | ERROR | ok     |
+| 5  | s3tests_boto3.functional.test_s3.test_object_lock_uploading_obj                                | ERROR | ERROR | ok     |
 | 6  | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_lock_invalid_years                   | FAIL  | ERROR | ok     |
 | 7  | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_lock_invalid_status                  | FAIL  | ERROR | ok     |
 | 8  | s3tests_boto3.functional.test_s3.test_object_lock_suspend_versioning                           | FAIL  | ERROR | ok     |
 | 9  | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_lock                                 | FAIL  | ERROR | ok     |
 | 10 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_lock_invalid_bucket                  | ok    | ok    | ok     |
-| 11 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention                            | ok    | ERROR | ok     |
+| 11 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention                            | ERROR | ERROR | ok     |
 | 12 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_invalid_bucket             | FAIL  | ok    | ok     |
 | 13 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_invalid_mode               | FAIL  | ERROR | ok     |
-| 14 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_retention                            | ok    | ERROR | ok     |
+| 14 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_retention                            | ERROR | ERROR | ok     |
 | 15 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_retention_invalid_bucket             | FAIL  | ok    | ok     |
-| 16 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_versionid                  | ok    | ERROR | ok     |
+| 16 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_versionid                  | ERROR | ERROR | ok     |
 | 17 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_override_default_retention | ERROR | ERROR | ok     |
 | 18 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_increase_period            | ERROR | ERROR | ok     |
 | 19 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_shorten_period             | FAIL  | ERROR | ok     |
-| 20 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_shorten_period_bypass      | ok    | ERROR | ok     |
-| 21 | s3tests_boto3.functional.test_s3.test_object_lock_delete_object_with_retention                 | FAIL  | ERROR | ok     |
-| 22 | s3tests_boto3.functional.test_s3.test_object_lock_put_legal_hold                               | ok    | ERROR | ok     |
+| 20 | s3tests_boto3.functional.test_s3.test_object_lock_put_obj_retention_shorten_period_bypass      | ERROR | ERROR | ok     |
+| 21 | s3tests_boto3.functional.test_s3.test_object_lock_delete_object_with_retention                 | ERROR | ERROR | ok     |
+| 22 | s3tests_boto3.functional.test_s3.test_object_lock_put_legal_hold                               | ERROR | ERROR | ok     |
 | 23 | s3tests_boto3.functional.test_s3.test_object_lock_put_legal_hold_invalid_bucket                | FAIL  | ok    | ok     |
 | 24 | s3tests_boto3.functional.test_s3.test_object_lock_put_legal_hold_invalid_status                | FAIL  | ERROR | ok     |
-| 25 | s3tests_boto3.functional.test_s3.test_object_lock_get_legal_hold                               | ok    | ERROR | ok     |
+| 25 | s3tests_boto3.functional.test_s3.test_object_lock_get_legal_hold                               | ERROR | ERROR | ok     |
 | 26 | s3tests_boto3.functional.test_s3.test_object_lock_get_legal_hold_invalid_bucket                | FAIL  | ok    | ok     |
-| 27 | s3tests_boto3.functional.test_s3.test_object_lock_delete_object_with_legal_hold_on             | FAIL  | ERROR | ok     |
+| 27 | s3tests_boto3.functional.test_s3.test_object_lock_delete_object_with_legal_hold_on             | ERROR | ERROR | ok     |
 | 28 | s3tests_boto3.functional.test_s3.test_object_lock_delete_object_with_legal_hold_off            | ok    | ERROR | ok     |
-| 29 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_metadata                             | ok    | ERROR | ok     |
+| 29 | s3tests_boto3.functional.test_s3.test_object_lock_get_obj_metadata                             | ERROR | ERROR | ok     |
 
 ## Multipart
 
@@ -384,7 +387,7 @@ Compatibility: 9/6/8 out of 11
 
 ## Versioning
 
-Compatibility: 22/19/24 out of 26
+Compatibility: 23/19/24 out of 26
 
 |    | Test                                                                                        | s3-gw | minio | aws s3 |
 |----|---------------------------------------------------------------------------------------------|-------|-------|--------|
@@ -397,7 +400,7 @@ Compatibility: 22/19/24 out of 26
 | 7  | s3tests_boto3.functional.test_s3.test_versioning_obj_suspend_versions                       | ok    | ok    | ok     |
 | 8  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_all             | ok    | ok    | ok     |
 | 9  | s3tests_boto3.functional.test_s3.test_versioning_obj_create_versions_remove_special_names   | ok    | ok    | ok     |
-| 10 | s3tests_boto3.functional.test_s3.test_versioning_obj_create_overwrite_multipart             | FAIL  | ok    | ok     |
+| 10 | s3tests_boto3.functional.test_s3.test_versioning_obj_create_overwrite_multipart             | ok    | ok    | ok     |
 | 11 | s3tests_boto3.functional.test_s3.test_versioning_obj_list_marker                            | ok    | ok    | ok     |
 | 12 | s3tests_boto3.functional.test_s3.test_versioning_copy_obj_version                           | ok    | ok    | ok     |
 | 13 | s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete                        | ok    | ok    | ok     |
@@ -483,7 +486,7 @@ Compatibility:  38/38/45 out of 59
 
 ## Bucket ACL
 
-Compatibility:  2/3/16 out of 33
+Compatibility:  3/3/16 out of 33
 This group is not explicitly supported by s3-gw, but some tests may pass.
 
 |    | Test                                                                                       | s3-gw | minio | aws s3 |
@@ -507,8 +510,8 @@ This group is not explicitly supported by s3-gw, but some tests may pass.
 | 17 | s3tests_boto3.functional.test_s3.test_bucket_acl_revoke_all                                | ERROR | ERROR | ok     |
 | 18 | s3tests_boto3.functional.test_s3.test_bucket_acl_canned_private_to_private                 | ok    | ok    | ok     |
 | 19 | s3tests_boto3.functional.test_s3.test_bucket_header_acl_grants                             | ERROR | FAIL  | FAIL   |
-| 20 | s3tests_boto3.functional.test_s3.test_access_bucket_private_object_private                 | ok    | FAIL  | ok     |
-| 21 | s3tests_boto3.functional.test_s3.test_access_bucket_private_objectv2_private               | ok    | FAIL  | ok     |
+| 20 | s3tests_boto3.functional.test_s3.test_access_bucket_private_object_private                 | FAIL  | FAIL  | ok     |
+| 21 | s3tests_boto3.functional.test_s3.test_access_bucket_private_objectv2_private               | FAIL  | FAIL  | ok     |
 | 22 | s3tests_boto3.functional.test_s3.test_access_bucket_private_object_publicread              | ERROR | ERROR | ok     |
 | 23 | s3tests_boto3.functional.test_s3.test_access_bucket_private_objectv2_publicread            | ERROR | ERROR | ok     |
 | 24 | s3tests_boto3.functional.test_s3.test_access_bucket_private_object_publicreadwrite         | ERROR | ERROR | ok     |
@@ -524,13 +527,13 @@ This group is not explicitly supported by s3-gw, but some tests may pass.
 
 ## CORS
 
-Compatibility: 3/0/3 out of 4
+Compatibility: 2/0/3 out of 4
 
 |   | Test                                                       | s3-gw | minio | aws s3 |
 |---|------------------------------------------------------------|-------|-------|--------|
 | 1 | s3tests_boto3.functional.test_s3.test_set_cors             | ok    | ERROR | ok     |
 | 2 | s3tests_boto3.functional.test_s3.test_cors_origin_response | FAIL  | ERROR | FAIL   |
-| 3 | s3tests_boto3.functional.test_s3.test_cors_origin_wildcard | ok    | ERROR | ok     |
+| 3 | s3tests_boto3.functional.test_s3.test_cors_origin_wildcard | FAIL  | ERROR | ok     |
 | 4 | s3tests_boto3.functional.test_s3.test_cors_header_option   | ok    | ERROR | ok     |
 
 ## Encryption
@@ -652,11 +655,11 @@ This group is not explicitly supported by s3-gw, but some tests may pass.
 
 ## Others
 
-Compatibility: 3/2/3 out of 6
+Compatibility: 2/2/3 out of 6
 
 |   | Test                                                        | s3-gw | minio | aws s3 |
 |---|-------------------------------------------------------------|-------|-------|--------|
-| 1 | s3tests_boto3.functional.test_s3.test_100_continue          | ok    | ERROR | ok     |
+| 1 | s3tests_boto3.functional.test_s3.test_100_continue          | FAIL  | ERROR | ok     |
 | 2 | s3tests_boto3.functional.test_s3.test_account_usage         | ERROR | ERROR | ERROR  |
 | 3 | s3tests_boto3.functional.test_s3.test_head_bucket_usage     | ERROR | ERROR | ERROR  |
 | 4 | s3tests_boto3.functional.test_s3.test_logging_toggle        | ERROR | ERROR | ERROR  |


### PR DESCRIPTION
Most of failed tests are broken because of https://github.com/nspcc-dev/neofs-node/issues/1628
After that we should look at lock tests: https://github.com/nspcc-dev/neofs-s3-gw/issues/639
Also this PR updates counters for non s3-gw columns.