### PR TITLE
[#645] Replace tagging when PutObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This document outlines major changes between releases.
 - Improved wallet configuration via `.yaml` config and environment variables (#607)
 ### Removed
 ### Fixed
-- Responses to `GetObject` and `HeadObject`: remove redundant `VersionID` (#577)  
+- Responses to `GetObject` and `HeadObject`: removed redundant `VersionID` (#577)
+- Replacement of object tagging in case of overwriting of an object (#645)
 ### Updating from v0.23.0
 1. Make sure configuration of wallet is valid. If you use:
    1. environment variables: set `S3_GW_WALLET_PATH` instead of `S3_GW_WALLET`, 


### PR DESCRIPTION
There is two approaches: 
1. Move existing version node and remove old tagging in subtree of new node
2. Remove old version node and put new version node

I prefer the first rather than the second because correct replace of node is more important and one request (move) leads to less chance to fail. 

Closes #645 