### PR TITLE
Optimize listing

### DIFF
--- a/api/handler/delete_test.go
+++ b/api/handler/delete_test.go
@@ -209,7 +209,7 @@ func TestDeleteObjectFromListCache(t *testing.T) {
 	bktName, objName := "bucket-for-removal", "object-to-delete"
 	bktInfo, objInfo := createVersionedBucketAndObject(t, tc, bktName, objName)
 
-	versions := listObjectsV1(t, tc, bktName)
+	versions := listObjectsV1(t, tc, bktName, "", "", "", -1)
 	require.Len(t, versions.Contents, 1)
 
 	checkFound(t, tc, bktName, objName, objInfo.VersionID())
@@ -217,7 +217,7 @@ func TestDeleteObjectFromListCache(t *testing.T) {
 	checkNotFound(t, tc, bktName, objName, objInfo.VersionID())
 
 	// check cache is clean after object removal
-	versions = listObjectsV1(t, tc, bktName)
+	versions = listObjectsV1(t, tc, bktName, "", "", "", -1)
 	require.Len(t, versions.Contents, 0)
 
 	require.False(t, existInMockedNeoFS(tc, bktInfo, objInfo))
@@ -312,15 +312,6 @@ func listVersions(t *testing.T, tc *handlerContext, bktName string) *ListObjects
 	tc.Handler().ListBucketObjectVersionsHandler(w, r)
 	assertStatus(t, w, http.StatusOK)
 	res := &ListObjectsVersionsResponse{}
-	parseTestResponse(t, w, res)
-	return res
-}
-
-func listObjectsV1(t *testing.T, tc *handlerContext, bktName string) *ListObjectsV1Response {
-	w, r := prepareTestRequest(t, bktName, "", nil)
-	tc.Handler().ListObjectsV1Handler(w, r)
-	assertStatus(t, w, http.StatusOK)
-	res := &ListObjectsV1Response{}
 	parseTestResponse(t, w, res)
 	return res
 }

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -121,30 +121,6 @@ func addEncryptionHeaders(meta map[string]string, enc encryption.Params) error {
 	return nil
 }
 
-// processObjectInfoName fixes name in objectInfo structure based on prefix and
-// delimiter from user request. If name does not contain prefix, nil value is
-// returned. If name should be modified, then function returns copy of objectInfo
-// structure.
-func processObjectInfoName(oi *data.ObjectInfo, prefix, delimiter string) *data.ObjectInfo {
-	if !strings.HasPrefix(oi.Name, prefix) {
-		return nil
-	}
-	if len(delimiter) == 0 {
-		return oi
-	}
-	copiedObjInfo := *oi
-	tail := strings.TrimPrefix(copiedObjInfo.Name, prefix)
-	index := strings.Index(tail, delimiter)
-	if index >= 0 {
-		copiedObjInfo.IsDir = true
-		copiedObjInfo.Size = 0
-		copiedObjInfo.Headers = nil
-		copiedObjInfo.ContentType = ""
-		copiedObjInfo.Name = prefix + tail[:index+1]
-	}
-	return &copiedObjInfo
-}
-
 func filenameFromObject(o *object.Object) string {
 	for _, attr := range o.Attributes() {
 		if attr.Key() == object.AttributeFileName {

--- a/api/layer/util_test.go
+++ b/api/layer/util_test.go
@@ -3,14 +3,12 @@ package layer
 import (
 	"encoding/hex"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/stretchr/testify/require"
@@ -22,30 +20,6 @@ var (
 	defaultTestPayloadLength = int64(len(defaultTestPayload))
 	defaultTestContentType   = http.DetectContentType(defaultTestPayload)
 )
-
-func newTestObject(id oid.ID, bkt *data.BucketInfo, name string) *object.Object {
-	filename := object.NewAttribute()
-	filename.SetKey(object.AttributeFileName)
-	filename.SetValue(name)
-
-	created := object.NewAttribute()
-	created.SetKey(object.AttributeTimestamp)
-	created.SetValue(strconv.FormatInt(defaultTestCreated.Unix(), 10))
-
-	contentType := object.NewAttribute()
-	contentType.SetKey(object.AttributeContentType)
-	contentType.SetValue(defaultTestContentType)
-
-	obj := object.New()
-	obj.SetID(id)
-	obj.SetOwnerID(&bkt.Owner)
-	obj.SetContainerID(bkt.CID)
-	obj.SetPayload(defaultTestPayload)
-	obj.SetAttributes(*filename, *created, *contentType)
-	obj.SetPayloadSize(uint64(defaultTestPayloadLength))
-
-	return obj
-}
 
 func newTestInfo(obj oid.ID, bkt *data.BucketInfo, name string, isDir bool) *data.ObjectInfo {
 	var hashSum checksum.Checksum
@@ -72,7 +46,16 @@ func newTestInfo(obj oid.ID, bkt *data.BucketInfo, name string, isDir bool) *dat
 	return info
 }
 
-func Test_objectInfoName(t *testing.T) {
+func newTestNodeVersion(id oid.ID, name string) *data.NodeVersion {
+	return &data.NodeVersion{
+		BaseNodeVersion: data.BaseNodeVersion{
+			OID:      id,
+			FilePath: name,
+		},
+	}
+}
+
+func TestTryDirectory(t *testing.T) {
 	var uid user.ID
 	var id oid.ID
 	var containerID cid.ID
@@ -88,77 +71,82 @@ func Test_objectInfoName(t *testing.T) {
 		name      string
 		prefix    string
 		result    *data.ObjectInfo
-		object    *object.Object
+		node      *data.NodeVersion
 		delimiter string
 	}{
 		{
 			name:   "small.jpg",
-			result: newTestInfo(id, bkt, "small.jpg", false),
-			object: newTestObject(id, bkt, "small.jpg"),
+			result: nil,
+			node:   newTestNodeVersion(id, "small.jpg"),
 		},
 		{
 			name:   "small.jpg not matched prefix",
 			prefix: "big",
 			result: nil,
-			object: newTestObject(id, bkt, "small.jpg"),
+			node:   newTestNodeVersion(id, "small.jpg"),
 		},
 		{
 			name:      "small.jpg delimiter",
 			delimiter: "/",
-			result:    newTestInfo(id, bkt, "small.jpg", false),
-			object:    newTestObject(id, bkt, "small.jpg"),
+			result:    nil,
+			node:      newTestNodeVersion(id, "small.jpg"),
 		},
 		{
 			name:   "test/small.jpg",
-			result: newTestInfo(id, bkt, "test/small.jpg", false),
-			object: newTestObject(id, bkt, "test/small.jpg"),
+			result: nil,
+			node:   newTestNodeVersion(id, "test/small.jpg"),
 		},
 		{
 			name:      "test/small.jpg with prefix and delimiter",
 			prefix:    "test/",
 			delimiter: "/",
-			result:    newTestInfo(id, bkt, "test/small.jpg", false),
-			object:    newTestObject(id, bkt, "test/small.jpg"),
+			result:    nil,
+			node:      newTestNodeVersion(id, "test/small.jpg"),
 		},
 		{
 			name:   "a/b/small.jpg",
 			prefix: "a",
-			result: newTestInfo(id, bkt, "a/b/small.jpg", false),
-			object: newTestObject(id, bkt, "a/b/small.jpg"),
+			result: nil,
+			node:   newTestNodeVersion(id, "a/b/small.jpg"),
 		},
 		{
 			name:      "a/b/small.jpg",
 			prefix:    "a/",
 			delimiter: "/",
 			result:    newTestInfo(id, bkt, "a/b/", true),
-			object:    newTestObject(id, bkt, "a/b/small.jpg"),
+			node:      newTestNodeVersion(id, "a/b/small.jpg"),
 		},
 		{
 			name:      "a/b/c/small.jpg",
 			prefix:    "a/",
 			delimiter: "/",
 			result:    newTestInfo(id, bkt, "a/b/", true),
-			object:    newTestObject(id, bkt, "a/b/c/small.jpg"),
+			node:      newTestNodeVersion(id, "a/b/c/small.jpg"),
 		},
 		{
 			name:      "a/b/c/small.jpg",
 			prefix:    "a/b/c/s",
 			delimiter: "/",
-			result:    newTestInfo(id, bkt, "a/b/c/small.jpg", false),
-			object:    newTestObject(id, bkt, "a/b/c/small.jpg"),
+			result:    nil,
+			node:      newTestNodeVersion(id, "a/b/c/small.jpg"),
 		},
 		{
 			name:      "a/b/c/big.jpg",
 			prefix:    "a/b/",
 			delimiter: "/",
 			result:    newTestInfo(id, bkt, "a/b/c/", true),
-			object:    newTestObject(id, bkt, "a/b/c/big.jpg"),
+			node:      newTestNodeVersion(id, "a/b/c/big.jpg"),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			info := processObjectInfoName(objectInfoFromMeta(bkt, tc.object), tc.prefix, tc.delimiter)
+			info := tryDirectory(bkt, tc.node, tc.prefix, tc.delimiter)
+			if tc.result != nil {
+				tc.result.Created = time.Time{}
+				tc.result.Owner = user.ID{}
+			}
+
 			require.Equal(t, tc.result, info)
 		})
 	}


### PR DESCRIPTION
This PR:
* limit generator with `max-keys` value to avoid get extra objects
* if object couldn't be `HEAD` from NeoFS we form it using `data.NodeVersion` (it doesn't have some fields: `createdAt`, `owner` but the `name`, `size` and `etag` are still valid)
* check if object is directory before request to NeoFS

Close #625, close #616 
