### PR TITLE
Fix object head after put

### DIFF
--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -594,7 +594,7 @@ func (n *layer) deleteObject(ctx context.Context, bkt *data.BucketInfo, settings
 		IsUnversioned: settings.VersioningSuspended(),
 	}
 
-	if obj.Error = n.treeService.AddVersion(ctx, bkt.CID, newVersion); obj.Error != nil {
+	if _, obj.Error = n.treeService.AddVersion(ctx, bkt.CID, newVersion); obj.Error != nil {
 		return obj
 	}
 

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -250,7 +250,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Object
 
 	newVersion.OID = id
 	newVersion.ETag = hex.EncodeToString(hash)
-	if err = n.treeService.AddVersion(ctx, p.BktInfo.CID, newVersion); err != nil {
+	if newVersion.ID, err = n.treeService.AddVersion(ctx, p.BktInfo.CID, newVersion); err != nil {
 		return nil, fmt.Errorf("couldn't add new verion to tree service: %w", err)
 	}
 

--- a/api/layer/tree_mock.go
+++ b/api/layer/tree_mock.go
@@ -202,19 +202,19 @@ func (t *TreeServiceMock) GetUnversioned(_ context.Context, cnrID cid.ID, object
 	return nil, ErrNodeNotFound
 }
 
-func (t *TreeServiceMock) AddVersion(_ context.Context, cnrID cid.ID, newVersion *data.NodeVersion) error {
+func (t *TreeServiceMock) AddVersion(_ context.Context, cnrID cid.ID, newVersion *data.NodeVersion) (uint64, error) {
 	cnrVersionsMap, ok := t.versions[cnrID.EncodeToString()]
 	if !ok {
 		t.versions[cnrID.EncodeToString()] = map[string][]*data.NodeVersion{
 			newVersion.FilePath: {newVersion},
 		}
-		return nil
+		return newVersion.ID, nil
 	}
 
 	versions, ok := cnrVersionsMap[newVersion.FilePath]
 	if !ok {
 		cnrVersionsMap[newVersion.FilePath] = []*data.NodeVersion{newVersion}
-		return nil
+		return newVersion.ID, nil
 	}
 
 	sort.Slice(versions, func(i, j int) bool {
@@ -239,7 +239,7 @@ func (t *TreeServiceMock) AddVersion(_ context.Context, cnrID cid.ID, newVersion
 
 	cnrVersionsMap[newVersion.FilePath] = append(result, newVersion)
 
-	return nil
+	return newVersion.ID, nil
 }
 
 func (t *TreeServiceMock) RemoveVersion(_ context.Context, cnrID cid.ID, nodeID uint64) error {

--- a/api/layer/tree_service.go
+++ b/api/layer/tree_service.go
@@ -58,7 +58,7 @@ type TreeService interface {
 	GetLatestVersionsByPrefix(ctx context.Context, cnrID cid.ID, prefix string) ([]*data.NodeVersion, error)
 	GetAllVersionsByPrefix(ctx context.Context, cnrID cid.ID, prefix string) ([]*data.NodeVersion, error)
 	GetUnversioned(ctx context.Context, cnrID cid.ID, objectName string) (*data.NodeVersion, error)
-	AddVersion(ctx context.Context, cnrID cid.ID, newVersion *data.NodeVersion) error
+	AddVersion(ctx context.Context, cnrID cid.ID, newVersion *data.NodeVersion) (uint64, error)
 	RemoveVersion(ctx context.Context, cnrID cid.ID, nodeID uint64) error
 
 	PutLock(ctx context.Context, cnrID cid.ID, nodeID uint64, lock *data.LockInfo) error


### PR DESCRIPTION
Close #682 

This PR updates tree service interface to return added node id in `AddVersion` method. 

---

```
# nosetests -v --nologcapture -s s3tests_boto3.functional.test_s3:test_get_obj_head_tagging
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.
s3tests_boto3.functional.test_s3.test_get_obj_head_tagging ... ok
```