### PR TITLE
Optimize PutLockInfo

### DIFF
--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -255,7 +255,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Object
 	}
 
 	if p.Lock != nil && (p.Lock.Retention != nil || p.Lock.LegalHold != nil) {
-		prm := &PutLockInfoParams{
+		putLockInfoPrms := &PutLockInfoParams{
 			ObjVersion: &ObjectVersion{
 				BktInfo:    p.BktInfo,
 				ObjectName: p.Object,
@@ -263,9 +263,10 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Object
 			},
 			NewLock:      p.Lock,
 			CopiesNumber: p.CopiesNumber,
+			NodeVersion:  newVersion, // provide new version to make one less tree service call in PutLockInfo
 		}
 
-		if err = n.PutLockInfo(ctx, prm); err != nil {
+		if err = n.PutLockInfo(ctx, putLockInfoPrms); err != nil {
 			return nil, err
 		}
 	}

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -34,11 +34,16 @@ func (n *layer) PutLockInfo(ctx context.Context, p *PutLockInfoParams) (err erro
 
 	versionNode := p.NodeVersion
 	// sometimes node version can be provided from executing context
-	// if value is not provided, make a tree service call
+	// if not, then receive node version from tree service
 	if versionNode == nil {
-		versionNode, err = n.getNodeVersion(ctx, p.ObjVersion)
-		if err != nil {
-			return err
+		// check cache if node version is stored inside extendedObjectVersion
+		versionNode = n.getNodeVersionFromCache(p.ObjVersion)
+		if versionNode == nil {
+			// else get node version from tree service
+			versionNode, err = n.getNodeVersion(ctx, p.ObjVersion)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a part of #669.

In this PR, `PutLockInfo` takes optional argument of tree service node. If this argument is provided, then `PutLockInfo` produces one less network call. It is useful for object upload.