### PR TITLE
[#705] Return go1.17 to CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go_versions: [ '1.18.x', '1.19.x' ]
+        go_versions: [ '1.17', '1.18.x', '1.19.x' ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We should definitely have tests running on the version of `go` from go.mod.

Signed-off-by: Denis Kirillov <denis@nspcc.ru>