### PR TITLE
[#729] Add error message to AbortMultipartUpload

### DIFF
--- a/api/handler/util.go
+++ b/api/handler/util.go
@@ -16,15 +16,17 @@ import (
 )
 
 func (h *handler) logAndSendError(w http.ResponseWriter, logText string, reqInfo *api.ReqInfo, err error, additional ...zap.Field) {
-	fields := []zap.Field{zap.String("request_id", reqInfo.RequestID),
+	code := api.WriteErrorResponse(w, reqInfo, transformToS3Error(err))
+	fields := []zap.Field{
+		zap.Int("status", code),
+		zap.String("request_id", reqInfo.RequestID),
 		zap.String("method", reqInfo.API),
-		zap.String("bucket_name", reqInfo.BucketName),
-		zap.String("object_name", reqInfo.ObjectName),
+		zap.String("bucket", reqInfo.BucketName),
+		zap.String("object", reqInfo.ObjectName),
+		zap.String("description", logText),
 		zap.Error(err)}
 	fields = append(fields, additional...)
-
-	h.log.Error(logText, fields...)
-	api.WriteErrorResponse(w, reqInfo, transformToS3Error(err))
+	h.log.Error("call method", fields...)
 }
 
 func transformToS3Error(err error) error {

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -536,7 +536,7 @@ func (n *layer) AbortMultipartUpload(ctx context.Context, p *UploadInfoParams) e
 	for _, info := range parts {
 		if err = n.objectDelete(ctx, p.Bkt, info.OID); err != nil {
 			n.log.Warn("couldn't delete part", zap.String("cid", p.Bkt.CID.EncodeToString()),
-				zap.String("oid", info.OID.EncodeToString()), zap.Int("part number", info.Number))
+				zap.String("oid", info.OID.EncodeToString()), zap.Int("part number", info.Number), zap.Error(err))
 		}
 	}
 

--- a/api/response.go
+++ b/api/response.go
@@ -110,7 +110,7 @@ var s3ErrorResponseMap = map[string]string{
 }
 
 // WriteErrorResponse writes error headers.
-func WriteErrorResponse(w http.ResponseWriter, reqInfo *ReqInfo, err error) {
+func WriteErrorResponse(w http.ResponseWriter, reqInfo *ReqInfo, err error) int {
 	code := http.StatusInternalServerError
 
 	if e, ok := err.(errors.Error); ok {
@@ -130,6 +130,7 @@ func WriteErrorResponse(w http.ResponseWriter, reqInfo *ReqInfo, err error) {
 	errorResponse := getAPIErrorResponse(reqInfo, err)
 	encodedErrorResponse := EncodeResponse(errorResponse)
 	WriteResponse(w, code, encodedErrorResponse, MimeXML)
+	return code
 }
 
 // If none of the http routes match respond with appropriate errors.

--- a/api/router.go
+++ b/api/router.go
@@ -149,6 +149,7 @@ func logErrorResponse(l *zap.Logger) mux.MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			lw := &logResponseWriter{ResponseWriter: w}
+			reqInfo := GetReqInfo(r.Context())
 
 			// pass execution:
 			h.ServeHTTP(lw, r)
@@ -159,6 +160,8 @@ func logErrorResponse(l *zap.Logger) mux.MiddlewareFunc {
 					zap.Int("status", lw.statusCode),
 					zap.String("request_id", GetRequestID(r.Context())),
 					zap.String("method", mux.CurrentRoute(r).GetName()),
+					zap.String("bucket", reqInfo.BucketName),
+					zap.String("object", reqInfo.ObjectName),
 					zap.String("description", http.StatusText(lw.statusCode)))
 
 				return
@@ -168,6 +171,8 @@ func logErrorResponse(l *zap.Logger) mux.MiddlewareFunc {
 				zap.Int("status", lw.statusCode),
 				zap.String("request_id", GetRequestID(r.Context())),
 				zap.String("method", mux.CurrentRoute(r).GetName()),
+				zap.String("bucket", reqInfo.BucketName),
+				zap.String("object", reqInfo.ObjectName),
 				zap.String("description", http.StatusText(lw.statusCode)))
 		})
 	}

--- a/api/router.go
+++ b/api/router.go
@@ -154,16 +154,8 @@ func logErrorResponse(l *zap.Logger) mux.MiddlewareFunc {
 			// pass execution:
 			h.ServeHTTP(lw, r)
 
-			// Ignore <300 status codes
-			if lw.statusCode >= http.StatusMultipleChoices {
-				l.Error("something went wrong",
-					zap.Int("status", lw.statusCode),
-					zap.String("request_id", GetRequestID(r.Context())),
-					zap.String("method", mux.CurrentRoute(r).GetName()),
-					zap.String("bucket", reqInfo.BucketName),
-					zap.String("object", reqInfo.ObjectName),
-					zap.String("description", http.StatusText(lw.statusCode)))
-
+			// Ignore >400 status codes
+			if lw.statusCode >= http.StatusBadRequest {
 				return
 			}
 


### PR DESCRIPTION
Closes #728 

Now it prints:
```
# Trying to head non-existing object 
2022-10-25T19:12:46.858+0400    e call method     {"status": 404, "request_id": "9d453cba-eeff-4814-ab59-8e95bb5a3665", "method": "HeadObject", "bucket": "test", "object": "c", "description": "could not find object", "error": "NoSuchKey: 404 => The specified key does not exist."}

# Trying to create a bucket with incorrect credentials
2022-10-25T19:16:44.016+0400    error   api/user_auth.go:30     failed to pass authentication   {"error": "get box: get access box: read payload: init full payload range reading via connection pool: read header: status: code = 2049 message = object not found"}

# Trying to put object
2022-10-25T19:13:35.055+0400     call method     {"status": 500, "request_id": "a2bf1363-2f15-4615-b33e-acce27ac5768", "method": "PutObject", "bucket": "test", "object": "b", "description": "could not upload object", "error": "save object via connection pool: init writing on API client: client failure: rpc error: code = Canceled desc = context canceled", "body close errors": []}

# Successful put-object
2022-10-25T19:17:16.725+0400    info    api/router.go:162       call method     {"status": 200, "request_id": "6e435f5d-168a-4385-b63e-1b28836109fe", "method": "PutObject", "bucket": "test", "object": "b", "description": "OK"}

# Successful delete-object
2022-10-25T19:17:35.955+0400    info    api/router.go:162       call method     {"status": 204, "request_id": "9b2d7b79-2404-42c0-a18c-135be46dbbaf", "method": "DeleteObject", "bucket": "test", "object": "b", "description": "No Content"}
```

