### PR TITLE
[#733] Fix container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document outlines major changes between releases.
 ### Fixed
 - Unrestricted access to not owned objects via cache (#713)
 - Check tree service health (#699)
+- Bucket names in listing (#733)
 
 ### Updating from v0.24.0
 New config parameters were added. Make sure the default parameters are appropriate for you.

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -55,7 +55,9 @@ func (n *layer) containerInfo(ctx context.Context, idCnr cid.ID) (*data.BucketIn
 	cnr := *res
 
 	info.Owner = cnr.Owner()
-	info.Name = container.Name(cnr)
+	if domain := container.ReadDomain(cnr); domain.Name() != "" {
+		info.Name = domain.Name()
+	}
 	info.Created = container.CreatedAt(cnr)
 	info.LocationConstraint = cnr.Attribute(attributeLocationConstraint)
 


### PR DESCRIPTION
User system name (`__NEOFS__NAME`) instead of regular one (`Name`). We shouldn't show user container name from regular attribute because the user cannot use it as bucket name when do request to s3-gw.
Set name as CID if name attribute is missed

close #733 
Signed-off-by: Denis Kirillov <denis@nspcc.ru>