### PR TITLE
[#726] Use client time on regular requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This document outlines major changes between releases.
 ### Fixed
 - Empty bucket policy (#740) 
 
+### Added
+- Use client time as `now` in some requests (#726)
+
 ### Changed
 - Placement policy configuration (#568)
 

--- a/api/handler/api.go
+++ b/api/handler/api.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"time"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
@@ -19,7 +20,7 @@ type (
 
 	Notificator interface {
 		SendNotifications(topics map[string]string, p *SendNotificationParams) error
-		SendTestNotification(topic, bucketName, requestID, HostID string) error
+		SendTestNotification(topic, bucketName, requestID, HostID string, now time.Time) error
 	}
 
 	// Config contains data which handler needs to keep.

--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -184,7 +184,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		CopiesNuber: copiesNumber,
 	}
 
-	params.Lock, err = formObjectLock(dstBktInfo, settings.LockConfiguration, r.Header)
+	params.Lock, err = formObjectLock(r.Context(), dstBktInfo, settings.LockConfiguration, r.Header)
 	if err != nil {
 		h.logAndSendError(w, "could not form object lock", reqInfo, err)
 		return

--- a/api/handler/locking_test.go
+++ b/api/handler/locking_test.go
@@ -19,6 +19,8 @@ import (
 const defaultURL = "http://localhost/"
 
 func TestFormObjectLock(t *testing.T) {
+	ctx := context.Background()
+
 	for _, tc := range []struct {
 		name          string
 		bktInfo       *data.BucketInfo
@@ -73,7 +75,7 @@ func TestFormObjectLock(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actualObjLock, err := formObjectLock(tc.bktInfo, tc.config, tc.header)
+			actualObjLock, err := formObjectLock(ctx, tc.bktInfo, tc.config, tc.header)
 			if tc.expectedError {
 				require.Error(t, err)
 				return
@@ -86,6 +88,8 @@ func TestFormObjectLock(t *testing.T) {
 }
 
 func TestFormObjectLockFromRetention(t *testing.T) {
+	ctx := context.Background()
+
 	for _, tc := range []struct {
 		name          string
 		retention     *data.Retention
@@ -132,7 +136,7 @@ func TestFormObjectLockFromRetention(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actualObjLock, err := formObjectLockFromRetention(tc.retention, tc.header)
+			actualObjLock, err := formObjectLockFromRetention(ctx, tc.retention, tc.header)
 			if tc.expectedError {
 				require.Error(t, err)
 				return

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -240,7 +240,7 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params.Lock, err = formObjectLock(bktInfo, settings.LockConfiguration, r.Header)
+	params.Lock, err = formObjectLock(r.Context(), bktInfo, settings.LockConfiguration, r.Header)
 	if err != nil {
 		h.logAndSendError(w, "could not form object lock", reqInfo, err)
 		return

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
@@ -116,7 +115,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 	bktInfo := &data.BucketInfo{
 		Name:               p.Name,
 		Owner:              ownerID,
-		Created:            time.Now(), // this can be a little incorrect since the real time is set later
+		Created:            TimeNow(ctx),
 		LocationConstraint: p.LocationConstraint,
 		ObjectLockEnabled:  p.ObjectLockEnabled,
 	}
@@ -138,6 +137,7 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 		Policy:               p.Policy,
 		Name:                 p.Name,
 		SessionToken:         p.SessionContainerCreation,
+		CreationTime:         bktInfo.Created,
 		AdditionalAttributes: attributes,
 	})
 	if err != nil {

--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -41,6 +41,7 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 		Creator:      p.BktInfo.Owner,
 		Payload:      p.Reader,
 		Filepath:     p.BktInfo.CORSObjectName(),
+		CreationTime: TimeNow(ctx),
 		CopiesNumber: p.CopiesNumber,
 	}
 

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -306,6 +306,15 @@ func IsAuthenticatedRequest(ctx context.Context) bool {
 	return ok
 }
 
+// TimeNow returns client time from request or time.Now().
+func TimeNow(ctx context.Context) time.Time {
+	if now, ok := ctx.Value(api.ClientTime).(time.Time); ok {
+		return now
+	}
+
+	return time.Now()
+}
+
 // Owner returns owner id from BearerToken (context) or from client owner.
 func (n *layer) Owner(ctx context.Context) user.ID {
 	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil && bd.Gate.BearerToken != nil {
@@ -565,7 +574,7 @@ func (n *layer) deleteObject(ctx context.Context, bkt *data.BucketInfo, settings
 			FilePath: obj.Name,
 		},
 		DeleteMarker: &data.DeleteMarkerInfo{
-			Created: time.Now(),
+			Created: TimeNow(ctx),
 			Owner:   n.Owner(ctx),
 		},
 		IsUnversioned: settings.VersioningSuspended(),

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -143,7 +143,7 @@ func (n *layer) CreateMultipartUpload(ctx context.Context, p *CreateMultipartPar
 		Key:          p.Info.Key,
 		UploadID:     p.Info.UploadID,
 		Owner:        n.Owner(ctx),
-		Created:      time.Now(),
+		Created:      TimeNow(ctx),
 		Meta:         make(map[string]string, metaSize),
 		CopiesNumber: p.CopiesNumber,
 	}
@@ -205,6 +205,7 @@ func (n *layer) uploadPart(ctx context.Context, multipartInfo *data.MultipartInf
 		Creator:      bktInfo.Owner,
 		Attributes:   make([][2]string, 2),
 		Payload:      p.Reader,
+		CreationTime: TimeNow(ctx),
 		CopiesNumber: multipartInfo.CopiesNumber,
 	}
 
@@ -234,7 +235,7 @@ func (n *layer) uploadPart(ctx context.Context, multipartInfo *data.MultipartInf
 		OID:      id,
 		Size:     decSize,
 		ETag:     hex.EncodeToString(hash),
-		Created:  time.Now(),
+		Created:  prm.CreationTime,
 	}
 
 	oldPartID, err := n.treeService.AddPart(ctx, bktInfo, multipartInfo.ID, partInfo)

--- a/api/layer/neofs.go
+++ b/api/layer/neofs.go
@@ -30,6 +30,9 @@ type PrmContainerCreate struct {
 	// Name for the container.
 	Name string
 
+	// CreationTime value for Timestamp attribute
+	CreationTime time.Time
+
 	// Token of the container's creation session. Nil means session absence.
 	SessionToken *session.Container
 
@@ -93,6 +96,9 @@ type PrmObjectCreate struct {
 
 	// Key-value object attributes.
 	Attributes [][2]string
+
+	// Value for Timestamp attribute (optional).
+	CreationTime time.Time
 
 	// List of ids to lock (optional).
 	Locks []oid.ID
@@ -204,11 +210,11 @@ type NeoFS interface {
 	// It returns any error encountered which prevented the removal request from being sent.
 	DeleteObject(context.Context, PrmObjectDelete) error
 
-	// TimeToEpoch computes current epoch and the epoch that corresponds to the provided time.
+	// TimeToEpoch computes current epoch and the epoch that corresponds to the provided now and future time.
 	// Note:
-	// * time must be in the future
-	// * time will be ceil rounded to match epoch
+	// * future time must be after the now
+	// * future time will be ceil rounded to match epoch
 	//
 	// It returns any error encountered which prevented computing epochs.
-	TimeToEpoch(context.Context, time.Time) (uint64, uint64, error)
+	TimeToEpoch(ctx context.Context, now time.Time, future time.Time) (uint64, uint64, error)
 }

--- a/api/layer/neofs_mock.go
+++ b/api/layer/neofs_mock.go
@@ -75,7 +75,12 @@ func (t *TestNeoFS) CreateContainer(_ context.Context, prm PrmContainerCreate) (
 	cnr.SetOwner(prm.Creator)
 	cnr.SetPlacementPolicy(prm.Policy)
 	cnr.SetBasicACL(prm.BasicACL)
-	container.SetCreationTime(&cnr, time.Now())
+
+	creationTime := prm.CreationTime
+	if creationTime.IsZero() {
+		creationTime = time.Now()
+	}
+	container.SetCreationTime(&cnr, creationTime)
 
 	if prm.Name != "" {
 		var d container.Domain
@@ -235,8 +240,8 @@ func (t *TestNeoFS) DeleteObject(ctx context.Context, prm PrmObjectDelete) error
 	return nil
 }
 
-func (t *TestNeoFS) TimeToEpoch(_ context.Context, futureTime time.Time) (uint64, uint64, error) {
-	return t.currentEpoch, t.currentEpoch + uint64(futureTime.Second()), nil
+func (t *TestNeoFS) TimeToEpoch(_ context.Context, now, futureTime time.Time) (uint64, uint64, error) {
+	return t.currentEpoch, t.currentEpoch + uint64(futureTime.Sub(now).Seconds()), nil
 }
 
 func (t *TestNeoFS) AllObjects(cnrID cid.ID) []oid.ID {

--- a/api/layer/notifications.go
+++ b/api/layer/notifications.go
@@ -30,6 +30,7 @@ func (n *layer) PutBucketNotificationConfiguration(ctx context.Context, p *PutBu
 		Creator:      p.BktInfo.Owner,
 		Payload:      bytes.NewReader(confXML),
 		Filepath:     p.BktInfo.NotificationConfigurationObjectName(),
+		CreationTime: TimeNow(ctx),
 		CopiesNumber: p.CopiesNumber,
 	}
 

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/minio/sio"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
@@ -234,6 +233,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		PayloadSize:  uint64(p.Size),
 		Filepath:     p.Object,
 		Payload:      r,
+		CreationTime: TimeNow(ctx),
 		CopiesNumber: p.CopiesNumber,
 	}
 
@@ -281,7 +281,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		Bucket:      p.BktInfo.Name,
 		Name:        p.Object,
 		Size:        p.Size,
-		Created:     time.Now(),
+		Created:     prm.CreationTime,
 		Headers:     p.Header,
 		ContentType: p.Header[api.ContentType],
 		HashSum:     newVersion.ETag,

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -116,6 +116,7 @@ func (n *layer) putLockObject(ctx context.Context, bktInfo *data.BucketInfo, obj
 		Container:    bktInfo.CID,
 		Creator:      bktInfo.Owner,
 		Locks:        []oid.ID{objID},
+		CreationTime: TimeNow(ctx),
 		CopiesNumber: copiesNumber,
 	}
 
@@ -227,7 +228,7 @@ func (n *layer) attributesFromLock(ctx context.Context, lock *data.ObjectLock) (
 	)
 
 	if lock.Retention != nil {
-		if _, expEpoch, err = n.neoFS.TimeToEpoch(ctx, lock.Retention.Until); err != nil {
+		if _, expEpoch, err = n.neoFS.TimeToEpoch(ctx, TimeNow(ctx), lock.Retention.Until); err != nil {
 			return nil, fmt.Errorf("fetch time to epoch: %w", err)
 		}
 

--- a/api/notifications/controller.go
+++ b/api/notifications/controller.go
@@ -197,11 +197,11 @@ func (c *Controller) SendNotifications(topics map[string]string, p *handler.Send
 	return nil
 }
 
-func (c *Controller) SendTestNotification(topic, bucketName, requestID, HostID string) error {
+func (c *Controller) SendTestNotification(topic, bucketName, requestID, HostID string, now time.Time) error {
 	event := &TestEvent{
 		Service:   "NeoFS S3",
 		Event:     "s3:TestEvent",
-		Time:      time.Now(),
+		Time:      now,
 		Bucket:    bucketName,
 		RequestID: requestID,
 		HostID:    HostID,
@@ -222,7 +222,7 @@ func prepareEvent(p *handler.SendNotificationParams) *Event {
 				EventVersion: EventVersion21,
 				EventSource:  "neofs:s3",
 				AWSRegion:    "",
-				EventTime:    time.Now(),
+				EventTime:    p.Time,
 				EventName:    p.Event,
 				UserIdentity: UserIdentity{
 					PrincipalID: p.User,

--- a/api/user_auth.go
+++ b/api/user_auth.go
@@ -16,6 +16,9 @@ type KeyWrapper string
 // BoxData is an ID used to store accessbox.Box in a context.
 var BoxData = KeyWrapper("__context_box_key")
 
+// ClientTime is an ID used to store client time.Time in a context.
+var ClientTime = KeyWrapper("__context_client_time")
+
 // AttachUserAuth adds user authentication via center to router using log for logging.
 func AttachUserAuth(router *mux.Router, center auth.Center, log *zap.Logger) {
 	router.Use(func(h http.Handler) http.Handler {
@@ -35,7 +38,10 @@ func AttachUserAuth(router *mux.Router, center auth.Center, log *zap.Logger) {
 					return
 				}
 			} else {
-				ctx = context.WithValue(r.Context(), BoxData, box)
+				ctx = context.WithValue(r.Context(), BoxData, box.AccessBox)
+				if !box.ClientTime.IsZero() {
+					ctx = context.WithValue(ctx, ClientTime, box.ClientTime)
+				}
 			}
 
 			h.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
Use `X-Amz-Date` header as `now` when
* compute expiration epoch
* set Timestamp for object and container
* forming locks
* send notifications

close #726 
Signed-off-by: Denis Kirillov <denis@nspcc.ru>