### PR TITLE
[#754] Add CID and OID to logs

### DIFF
--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -348,6 +348,13 @@ func (h *handler) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.log.Debug("copy details",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName),
+		zap.Stringer("cid", bktInfo.CID),
+		zap.String("object", reqInfo.ObjectName),
+		zap.Stringer("oid", info.ID))
+
 	response := UploadPartCopyResponse{
 		ETag:         info.HashSum,
 		LastModified: info.Created.UTC().Format(time.RFC3339),

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -730,6 +730,9 @@ func (h *handler) CreateBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.log.Debug("target details", zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName), zap.Stringer("cid", bktInfo.CID))
+
 	if p.ObjectLockEnabled {
 		sp := &layer.PutSettingsParams{
 			BktInfo:  bktInfo,

--- a/api/handler/tagging.go
+++ b/api/handler/tagging.go
@@ -52,6 +52,13 @@ func (h *handler) PutObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	h.log.Debug("target details",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName),
+		zap.Stringer("cid", bktInfo.CID),
+		zap.String("object", reqInfo.ObjectName),
+		zap.Stringer("oid", nodeVersion.OID))
+
 	s := &SendNotificationParams{
 		Event: EventObjectTaggingPut,
 		NotificationInfo: &data.NotificationInfo{
@@ -99,6 +106,13 @@ func (h *handler) GetObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	h.log.Debug("target details",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName),
+		zap.Stringer("cid", bktInfo.CID),
+		zap.String("object", reqInfo.ObjectName),
+		zap.String("oid", versionID))
+
 	if settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, versionID)
 	}
@@ -127,6 +141,13 @@ func (h *handler) DeleteObjectTaggingHandler(w http.ResponseWriter, r *http.Requ
 		h.logAndSendError(w, "could not delete object tagging", reqInfo, err)
 		return
 	}
+
+	h.log.Debug("target details",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName),
+		zap.Stringer("cid", bktInfo.CID),
+		zap.String("object", reqInfo.ObjectName),
+		zap.Stringer("oid", nodeVersion.OID))
 
 	s := &SendNotificationParams{
 		Event: EventObjectTaggingDelete,

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/minio/sio"
+	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	"github.com/nspcc-dev/neofs-s3-gw/api/errors"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer/encryption"
@@ -227,6 +228,13 @@ func (n *layer) uploadPart(ctx context.Context, multipartInfo *data.MultipartInf
 	if err != nil {
 		return nil, err
 	}
+
+	reqInfo := api.GetReqInfo(ctx)
+	n.log.Debug("upload part",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", bktInfo.Name), zap.Stringer("cid", bktInfo.CID),
+		zap.String("multipart upload", p.Info.UploadID),
+		zap.Int("part number", p.PartNumber), zap.String("object", p.Info.Key), zap.Stringer("oid", id))
 
 	partInfo := &data.PartInfo{
 		Key:      p.Info.Key,
@@ -535,6 +543,11 @@ func (n *layer) AbortMultipartUpload(ctx context.Context, p *UploadInfoParams) e
 	}
 
 	for _, info := range parts {
+		reqInfo := api.GetReqInfo(ctx)
+		n.log.Debug("part details",
+			zap.String("reqId", reqInfo.RequestID),
+			zap.String("bucket", p.Bkt.Name), zap.Stringer("cid", p.Bkt.CID),
+			zap.String("object", info.Key), zap.Stringer("oid", info.OID))
 		if err = n.objectDelete(ctx, p.Bkt, info.OID); err != nil {
 			n.log.Warn("couldn't delete part", zap.String("cid", p.Bkt.CID.EncodeToString()),
 				zap.String("oid", info.OID.EncodeToString()), zap.Int("part number", info.Number), zap.Error(err))
@@ -562,6 +575,11 @@ func (n *layer) ListParts(ctx context.Context, p *ListPartsParams) (*ListPartsIn
 	parts := make([]*Part, 0, len(partsInfo))
 
 	for _, partInfo := range partsInfo {
+		reqInfo := api.GetReqInfo(ctx)
+		n.log.Debug("part details",
+			zap.String("reqId", reqInfo.RequestID),
+			zap.String("container", p.Info.Bkt.Name), zap.Stringer("cid", p.Info.Bkt.CID),
+			zap.String("object", partInfo.Key), zap.Stringer("oid", partInfo.OID))
 		parts = append(parts, &Part{
 			ETag:         partInfo.ETag,
 			LastModified: partInfo.Created.UTC().Format(time.RFC3339),
@@ -609,9 +627,23 @@ func (n *layer) getUploadParts(ctx context.Context, p *UploadInfoParams) (*data.
 	}
 
 	res := make(map[int]*data.PartInfo, len(parts))
-	for _, part := range parts {
+	partsNumbers := make([]int, len(parts))
+	oids := make([]string, len(parts))
+	for i, part := range parts {
 		res[part.Number] = part
+		partsNumbers[i] = part.Number
+		oids[i] = part.OID.EncodeToString()
 	}
+
+	reqInfo := api.GetReqInfo(ctx)
+	n.log.Debug("part details",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", p.Bkt.Name),
+		zap.Stringer("cid", p.Bkt.CID),
+		zap.String("object", p.Key),
+		zap.String("upload id", p.UploadID),
+		zap.Ints("part numbers", partsNumbers),
+		zap.Strings("oids", oids))
 
 	return multipartInfo, res, nil
 }

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -248,6 +248,12 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		return nil, err
 	}
 
+	reqInfo := api.GetReqInfo(ctx)
+	n.log.Debug("put object",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", p.BktInfo.Name), zap.Stringer("cid", p.BktInfo.CID),
+		zap.String("object", p.Object), zap.Stringer("oid", id))
+
 	newVersion.OID = id
 	newVersion.ETag = hex.EncodeToString(hash)
 	if newVersion.ID, err = n.treeService.AddVersion(ctx, p.BktInfo, newVersion); err != nil {


### PR DESCRIPTION
Signed-off-by: Artem Tataurov <a.tataurov@yadro.com>

Close/Closes #754

Most handlers have the logging call on first levels.
Some of them rely on logging calls placed deeper at `getNodeVersion` and `getNodeVersionFromCache`: this is for cases when OID is not available for higher levels. Examples:
* DeleteObjectHandler
* DeleteMultipleObjectsHandler
* AbortMultipartUploadHandler
* PutObjectRetentionHandler
* GetObjectRetentionHandler
* PutObjectLegalHoldHandler
* GetObjectLegalHoldHandler
* ListMultipartUploadsHandler
* ListPartsHandler