### PR TITLE
[#754] Remove logging from ListParts

### DIFF
--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -348,13 +348,6 @@ func (h *handler) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.log.Debug("copy details",
-		zap.String("reqId", reqInfo.RequestID),
-		zap.String("bucket", reqInfo.BucketName),
-		zap.Stringer("cid", bktInfo.CID),
-		zap.String("object", reqInfo.ObjectName),
-		zap.Stringer("oid", info.ID))
-
 	response := UploadPartCopyResponse{
 		ETag:         info.HashSum,
 		LastModified: info.Created.UTC().Format(time.RFC3339),

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -730,8 +730,8 @@ func (h *handler) CreateBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.log.Debug("target details", zap.String("reqId", reqInfo.RequestID),
-		zap.String("bucket", reqInfo.BucketName), zap.Stringer("cid", bktInfo.CID))
+	h.log.Info("bucket is created", zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", reqInfo.BucketName), zap.Stringer("container_id", bktInfo.CID))
 
 	if p.ObjectLockEnabled {
 		sp := &layer.PutSettingsParams{
@@ -744,8 +744,6 @@ func (h *handler) CreateBucketHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	h.log.Info("bucket is created", zap.Stringer("container_id", bktInfo.CID))
 
 	api.WriteSuccessResponseHeadersOnly(w)
 }

--- a/api/handler/tagging.go
+++ b/api/handler/tagging.go
@@ -52,13 +52,6 @@ func (h *handler) PutObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.log.Debug("target details",
-		zap.String("reqId", reqInfo.RequestID),
-		zap.String("bucket", reqInfo.BucketName),
-		zap.Stringer("cid", bktInfo.CID),
-		zap.String("object", reqInfo.ObjectName),
-		zap.Stringer("oid", nodeVersion.OID))
-
 	s := &SendNotificationParams{
 		Event: EventObjectTaggingPut,
 		NotificationInfo: &data.NotificationInfo{
@@ -106,13 +99,6 @@ func (h *handler) GetObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.log.Debug("target details",
-		zap.String("reqId", reqInfo.RequestID),
-		zap.String("bucket", reqInfo.BucketName),
-		zap.Stringer("cid", bktInfo.CID),
-		zap.String("object", reqInfo.ObjectName),
-		zap.String("oid", versionID))
-
 	if settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, versionID)
 	}
@@ -141,13 +127,6 @@ func (h *handler) DeleteObjectTaggingHandler(w http.ResponseWriter, r *http.Requ
 		h.logAndSendError(w, "could not delete object tagging", reqInfo, err)
 		return
 	}
-
-	h.log.Debug("target details",
-		zap.String("reqId", reqInfo.RequestID),
-		zap.String("bucket", reqInfo.BucketName),
-		zap.Stringer("cid", bktInfo.CID),
-		zap.String("object", reqInfo.ObjectName),
-		zap.Stringer("oid", nodeVersion.OID))
 
 	s := &SendNotificationParams{
 		Event: EventObjectTaggingDelete,

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -543,11 +543,6 @@ func (n *layer) AbortMultipartUpload(ctx context.Context, p *UploadInfoParams) e
 	}
 
 	for _, info := range parts {
-		reqInfo := api.GetReqInfo(ctx)
-		n.log.Debug("part details",
-			zap.String("reqId", reqInfo.RequestID),
-			zap.String("bucket", p.Bkt.Name), zap.Stringer("cid", p.Bkt.CID),
-			zap.String("object", info.Key), zap.Stringer("oid", info.OID))
 		if err = n.objectDelete(ctx, p.Bkt, info.OID); err != nil {
 			n.log.Warn("couldn't delete part", zap.String("cid", p.Bkt.CID.EncodeToString()),
 				zap.String("oid", info.OID.EncodeToString()), zap.Int("part number", info.Number), zap.Error(err))
@@ -575,11 +570,6 @@ func (n *layer) ListParts(ctx context.Context, p *ListPartsParams) (*ListPartsIn
 	parts := make([]*Part, 0, len(partsInfo))
 
 	for _, partInfo := range partsInfo {
-		reqInfo := api.GetReqInfo(ctx)
-		n.log.Debug("part details",
-			zap.String("reqId", reqInfo.RequestID),
-			zap.String("container", p.Info.Bkt.Name), zap.Stringer("cid", p.Info.Bkt.CID),
-			zap.String("object", partInfo.Key), zap.Stringer("oid", partInfo.OID))
 		parts = append(parts, &Part{
 			ETag:         partInfo.ETag,
 			LastModified: partInfo.Created.UTC().Format(time.RFC3339),


### PR DESCRIPTION
Closes #754 

Removed logging from ListParts at `layer/multipart_upload.go` since more detailed logging happens in `getUploadParts` that gets called in ListParts.

Signed-off-by: Artem Tataurov <a.tataurov@yadro.com>