### PR TITLE
neofs: don't panic on missing signer key for request, fix #784

### DIFF
--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -262,7 +262,7 @@ func (x *NeoFS) CreateObject(ctx context.Context, prm layer.PrmObjectCreate) (oi
 
 	if prm.BearerToken != nil {
 		prmPut.UseBearer(*prm.BearerToken)
-	} else {
+	} else if prm.PrivateKey != nil {
 		prmPut.UseSigner(neofsecdsa.SignerRFC6979(*prm.PrivateKey))
 	}
 
@@ -301,7 +301,7 @@ func (x *NeoFS) ReadObject(ctx context.Context, prm layer.PrmObjectRead) (*layer
 
 	if prm.BearerToken != nil {
 		prmGet.UseBearer(*prm.BearerToken)
-	} else {
+	} else if prm.PrivateKey != nil {
 		prmGet.UseSigner(neofsecdsa.SignerRFC6979(*prm.PrivateKey))
 	}
 
@@ -334,7 +334,7 @@ func (x *NeoFS) ReadObject(ctx context.Context, prm layer.PrmObjectRead) (*layer
 
 		if prm.BearerToken != nil {
 			prmHead.UseBearer(*prm.BearerToken)
-		} else {
+		} else if prm.PrivateKey != nil {
 			prmHead.UseSigner(neofsecdsa.SignerRFC6979(*prm.PrivateKey))
 		}
 
@@ -369,7 +369,7 @@ func (x *NeoFS) ReadObject(ctx context.Context, prm layer.PrmObjectRead) (*layer
 
 	if prm.BearerToken != nil {
 		prmRange.UseBearer(*prm.BearerToken)
-	} else {
+	} else if prm.PrivateKey != nil {
 		prmRange.UseSigner(neofsecdsa.SignerRFC6979(*prm.PrivateKey))
 	}
 
@@ -393,7 +393,7 @@ func (x *NeoFS) DeleteObject(ctx context.Context, prm layer.PrmObjectDelete) err
 
 	if prm.BearerToken != nil {
 		prmDelete.UseBearer(*prm.BearerToken)
-	} else {
+	} else if prm.PrivateKey != nil {
 		prmDelete.UseSigner(neofsecdsa.SignerRFC6979(*prm.PrivateKey))
 	}
 


### PR DESCRIPTION
It's always nil here and it's OK because there is a key in the pool. Broken by 64a38a4ac7b1f5e74c538583c5df0c51cfb61c79.