### PR TITLE
handler: return 200 from PutBucketVersioning

### DIFF
--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -52,7 +52,9 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 
 	if err = h.obj.PutBucketSettings(r.Context(), p); err != nil {
 		h.logAndSendError(w, "couldn't put update versioning settings", reqInfo, err)
+		return
 	}
+	api.WriteSuccessResponseHeadersOnly(w)
 }
 
 // GetBucketVersioningHandler implements bucket versioning getter handler.


### PR DESCRIPTION
Status "0" is obviously wrong here:
2023-06-14T16:52:41.092Z        info    api/router.go:162       call method     {"status": 0, "host": "s3.neofs.devenv:8080", "request_id": "30aa2d82-5cca-4c9c-9b24-41450d708990", "method": "PutBucketVersioning", "bucket": "08ba13ed-3d5d-45c0-a4b7-8a544b016ec5", "object": "", "description": ""}

Related to #791.