### PR TITLE
Fix image build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20-alpine as builder
 
 ARG BUILD=now
 ARG REPO=github.com/nspcc-dev/neofs-s3-gw
@@ -6,6 +6,8 @@ ARG VERSION=dev
 
 WORKDIR /src
 COPY . /src
+
+RUN apk add --no-cache jq make bash curl
 
 RUN make
 


### PR DESCRIPTION
closes #814 

Changing to _Alpine_ version is required to install `jq` package. But this alpine image doesn't contain some important packages, thus installed them too.

Using jq also required because it formats JSON from Github request and we _grep_ results from it