### PR TITLE
Update test-env bump node and IR versions

### DIFF
--- a/.github/test-env
+++ b/.github/test-env
@@ -18,11 +18,11 @@ NEO_GO_PLATFORM=linux-amd64
 NEO_GO_URL=https://github.com/nspcc-dev/neo-go/releases/download/v${NEOGO_VERSION}/neo-go-${NEO_GO_PLATFORM}
 
 # NeoFS InnerRing nodes
-IR_VERSION=0.37.0
+IR_VERSION=0.38.1
 IR_IMAGE=nspccdev/neofs-ir
 
 # NeoFS Storage nodes
-NODE_VERSION=0.37.0
+NODE_VERSION=0.38.1
 NODE_IMAGE=nspccdev/neofs-storage
 NODE_PLATFORM=amd64
 


### PR DESCRIPTION
Node and IR versions bumped to 0.38.1 for S3-tests dev-env