### PR TITLE
workflows: Add missing step

### DIFF
--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get the current date
+        id: date
+        shell: bash
+        run: echo "::set-output name=timestamp::$(date +%s)"
 
       - name: Set RUN_ID
         env:


### PR DESCRIPTION
Added missing step "Get the current date".
Without this step, the RUN_ID variable had an invalid value in it. For example:
"RUN_ID: 34-"