### PR TITLE
Extend docs about Authenticated Users group

### DIFF
--- a/docs/aws_s3_compat.md
+++ b/docs/aws_s3_compat.md
@@ -51,7 +51,8 @@ Principal must be `"AWS": "*"` (to refer all users) or `"CanonicalUser": "0313b1
 }
 ```
 * AWS conditions and wildcard are not supported in [resources](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html)
-* Only `CanonicalUser` (with hex encoded public key) and `All Users Group` are supported in [ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html)
+* Only `CanonicalUser` (with hex encoded public key) and `All Users Group` are supported in [ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html).
+`Authenticated Users group` is not supported. It is a part of `All Users Group` and can't be separated from it.
 
 |    | Method       | Comments        |
 |----|--------------|-----------------|


### PR DESCRIPTION
We explicitly mention GW doesn't support this group. Because in NeoFS only two groups: owner and others. Right now there is no possible way to determine who is who.

Closes #858.