### PR TITLE
Return not supported error for PutObjectLegalHold command if OFF state

### DIFF
--- a/api/handler/locking_test.go
+++ b/api/handler/locking_test.go
@@ -436,10 +436,7 @@ func TestObjectLegalHold(t *testing.T) {
 	putObjectLegalHold(hc, bktName, objName, legalHoldOn)
 
 	putObjectLegalHold(hc, bktName, objName, legalHoldOff)
-	getObjectLegalHold(hc, bktName, objName, legalHoldOff)
-
-	// to make sure put hold is an idempotent operation
-	putObjectLegalHold(hc, bktName, objName, legalHoldOff)
+	getObjectLegalHold(hc, bktName, objName, legalHoldOn)
 }
 
 func getObjectLegalHold(hc *handlerContext, bktName, objName, status string) {
@@ -451,7 +448,11 @@ func getObjectLegalHold(hc *handlerContext, bktName, objName, status string) {
 func putObjectLegalHold(hc *handlerContext, bktName, objName, status string) {
 	w, r := prepareTestRequest(hc, bktName, objName, &data.LegalHold{Status: status})
 	hc.Handler().PutObjectLegalHoldHandler(w, r)
-	assertStatus(hc.t, w, http.StatusOK)
+	if status == legalHoldOn {
+		assertStatus(hc.t, w, http.StatusOK)
+	} else {
+		assertStatus(hc.t, w, http.StatusNotImplemented)
+	}
 }
 
 func assertLegalHold(t *testing.T, w *httptest.ResponseRecorder, status string) {

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -84,10 +84,7 @@ func (n *layer) PutLockInfo(ctx context.Context, p *PutLockInfoParams) (err erro
 			}
 			lockInfo.SetLegalHold(legalHoldOID)
 		} else if !newLock.LegalHold.Enabled && lockInfo.IsLegalHoldSet() {
-			if err = n.objectDelete(ctx, p.ObjVersion.BktInfo, lockInfo.LegalHold()); err != nil {
-				return fmt.Errorf("couldn't delete lock object '%s' to remove legal hold: %w", lockInfo.LegalHold().EncodeToString(), err)
-			}
-			lockInfo.ResetLegalHold()
+			return s3errors.GetAPIError(s3errors.ErrNotSupported)
 		}
 	}
 

--- a/docs/aws_s3_compat.md
+++ b/docs/aws_s3_compat.md
@@ -63,7 +63,7 @@ Principal must be `"AWS": "*"` (to refer all users) or `"CanonicalUser": "0313b1
 
 For now there are some limitations:
 * Retention period can't be shortened, only extended.
-* You can't delete locks or object with unexpired lock.
+* You can't delete locks or object with unexpired lock. This means PutObjectLegalHold with OFF status raise Unsupported error.
 
 |     | Method                     | Comments                  |
 |-----|----------------------------|---------------------------|


### PR DESCRIPTION
Lock object can't be deleted with Delete call, https://github.com/nspcc-dev/neofs-api/blob/1424834f743842b88e02ec6ac79c64ef2d2d3e75/lock/types.proto#L13.

Closes #868.