### PR TITLE
Store CORS to the object

### DIFF
--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -39,7 +39,7 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 	prm := PrmObjectCreate{
 		Container:    p.BktInfo.CID,
 		Creator:      p.BktInfo.Owner,
-		Payload:      p.Reader,
+		Payload:      &buf,
 		Filepath:     p.BktInfo.CORSObjectName(),
 		CreationTime: TimeNow(ctx),
 		CopiesNumber: p.CopiesNumber,


### PR DESCRIPTION
The reader already empty in this point, but buffer contains required data.

Closes #841.