### PR TITLE
Sort parts by number and server creation time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache: true
+          go-version: '1.21'
+
       - name: Get tree-service client
         run: make sync-tree
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
 

--- a/api/data/tree.go
+++ b/api/data/tree.go
@@ -85,7 +85,10 @@ type PartInfo struct {
 	OID      oid.ID
 	Size     int64
 	ETag     string
-	Created  time.Time
+	// Creation time from the client.
+	Created time.Time
+	// Server creation time.
+	ServerCreated time.Time
 }
 
 // ToHeaderString form short part representation to use in S3-Completed-Parts header.

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -19,6 +19,7 @@ import (
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -615,6 +616,23 @@ func (n *layer) getUploadParts(ctx context.Context, p *UploadInfoParams) (*data.
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Sort parts by part number, then by server creation time to make actual last uploaded parts with the same number.
+	slices.SortFunc(parts, func(a, b *data.PartInfo) int {
+		if a.Number < b.Number {
+			return -1
+		}
+
+		if a.ServerCreated.Before(b.ServerCreated) {
+			return -1
+		}
+
+		if a.ServerCreated.Equal(b.ServerCreated) {
+			return 0
+		}
+
+		return 1
+	})
 
 	res := make(map[int]*data.PartInfo, len(parts))
 	partsNumbers := make([]int, len(parts))

--- a/cmd/s3-authmate/main.go
+++ b/cmd/s3-authmate/main.go
@@ -301,7 +301,7 @@ It will be ceil rounded to the nearest amount of epoch.`,
 				Destination: &slicerEnabledFlag,
 			},
 		},
-		Action: func(c *cli.Context) error {
+		Action: func(_ *cli.Context) error {
 			ctx, log := prepare()
 
 			password := wallet.GetPassword(viper.GetViper(), envWalletPassphrase)
@@ -465,7 +465,7 @@ It will be ceil rounded to the nearest amount of epoch.`,
 				Destination: &secretAccessKeyFlag,
 			},
 		},
-		Action: func(c *cli.Context) error {
+		Action: func(_ *cli.Context) error {
 			var cfg aws.Config
 			if regionFlag != "" {
 				cfg.Region = &regionFlag
@@ -646,7 +646,7 @@ func obtainSecret() *cli.Command {
 				Value:       poolStreamTimeout,
 			},
 		},
-		Action: func(c *cli.Context) error {
+		Action: func(_ *cli.Context) error {
 			ctx, log := prepare()
 
 			password := wallet.GetPassword(viper.GetViper(), envWalletPassphrase)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.17.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -34,7 +35,6 @@ require (
 	github.com/nspcc-dev/go-ordered-json v0.0.0-20231123160306-3374ff1e7a3c // indirect
 	github.com/nspcc-dev/hrw/v2 v2.0.0-20231115095647-bf62f4ad0a43 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 )

--- a/internal/neofs/tree.go
+++ b/internal/neofs/tree.go
@@ -70,6 +70,7 @@ const (
 	isDeleteMarkerKV = "IsDeleteMarker"
 	ownerKV          = "Owner"
 	createdKV        = "Created"
+	serverCreatedKV  = "SrvCreated"
 
 	settingsFileName      = "bucket-settings"
 	notifConfFileName     = "bucket-notifications"
@@ -259,6 +260,12 @@ func newPartInfo(node NodeResponse) (*data.PartInfo, error) {
 				return nil, fmt.Errorf("invalid created timestamp: %w", err)
 			}
 			partInfo.Created = time.UnixMilli(utcMilli)
+		case serverCreatedKV:
+			var utcMilli int64
+			if utcMilli, err = strconv.ParseInt(value, 10, 64); err != nil {
+				return nil, fmt.Errorf("invalid server created timestamp: %w", err)
+			}
+			partInfo.ServerCreated = time.UnixMilli(utcMilli)
 		}
 	}
 
@@ -903,11 +910,12 @@ func (c *TreeClient) AddPart(ctx context.Context, bktInfo *data.BucketInfo, mult
 	}
 
 	meta := map[string]string{
-		partNumberKV: strconv.Itoa(info.Number),
-		oidKV:        info.OID.EncodeToString(),
-		sizeKV:       strconv.FormatInt(info.Size, 10),
-		createdKV:    strconv.FormatInt(info.Created.UTC().UnixMilli(), 10),
-		etagKV:       info.ETag,
+		partNumberKV:    strconv.Itoa(info.Number),
+		oidKV:           info.OID.EncodeToString(),
+		sizeKV:          strconv.FormatInt(info.Size, 10),
+		createdKV:       strconv.FormatInt(info.Created.UTC().UnixMilli(), 10),
+		serverCreatedKV: strconv.FormatInt(time.Now().UTC().UnixMilli(), 10),
+		etagKV:          info.ETag,
 	}
 
 	var foundPartID uint64


### PR DESCRIPTION
Closes #901.

During my first review, I didn't make two fields sort, only one - this was an error point.

Runed
```
S3TEST_CONF=s3tests.conf tox -- s3tests_boto3/functional/test_s3.py::test_multipart_resend --disable-warnings
```

Before changes
```
80 failed, 70 passed in 408.67s (0:06:48)
```

After changes
```
150 passed in 402.04s (0:06:42)
```