### PR TITLE
neofs/tree: don't use neofs-crypto directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.9.23 // indirect
 	github.com/nats-io/nkeys v0.4.6 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/nspcc-dev/neofs-crypto v0.4.0
+	github.com/nspcc-dev/neofs-crypto v0.4.0 // indirect
 	github.com/nspcc-dev/rfc6979 v0.2.0 // indirect
 	github.com/nspcc-dev/tzhash v1.7.1 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect

--- a/internal/neofs/tree_signature.go
+++ b/internal/neofs/tree_signature.go
@@ -2,7 +2,7 @@
 package neofs
 
 import (
-	crypto "github.com/nspcc-dev/neofs-crypto"
+	neofsecdsa "github.com/nspcc-dev/neofs-sdk-go/crypto/ecdsa"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -10,7 +10,8 @@ func (c *TreeClient) signData(buf []byte, f func(key, sign []byte)) error {
 	// crypto package should not be used outside of API libraries (see neofs-node#491).
 	// For now tree service does not include into SDK Client nor SDK Pool, so there is no choice.
 	// When SDK library adopts Tree service client, this should be dropped.
-	sign, err := crypto.Sign(&c.key.PrivateKey, buf)
+	var pk = neofsecdsa.Signer(c.key.PrivateKey)
+	sign, err := pk.Sign(buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
SDK is still a better option.