### PR TITLE
Do not use `github.com/nspcc-dev/neofs-api-go/v2 module` directly

### DIFF
--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
-	v2acl "github.com/nspcc-dev/neofs-api-go/v2/acl"
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	"github.com/nspcc-dev/neofs-s3-gw/api/layer"
@@ -685,7 +684,7 @@ func resInfoFromFilters(bucketName string, filters []eacl.Filter) resourceInfo {
 		if filter.Matcher() == eacl.MatchStringEqual {
 			if filter.Key() == object.AttributeFilePath {
 				resInfo.Object = filter.Value()
-			} else if filter.Key() == v2acl.FilterObjectID {
+			} else if filter.Key() == eacl.FilterObjectID {
 				resInfo.Version = filter.Value()
 			}
 		}

--- a/authmate/session_tokens.go
+++ b/authmate/session_tokens.go
@@ -11,7 +11,7 @@ import (
 type (
 	sessionTokenModel struct {
 		Verb        string `json:"verb"`
-		ContainerID string `json:"ContainerID"`
+		ContainerID string `json:"containerID"`
 	}
 
 	sessionTokenContext struct {

--- a/authmate/session_tokens.go
+++ b/authmate/session_tokens.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	apisession "github.com/nspcc-dev/neofs-api-go/v2/session"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 )
@@ -21,6 +20,13 @@ type (
 	}
 )
 
+// JSON strings for supported container session verbs.
+const (
+	containerSessionVerbPut     = "PUT"
+	containerSessionVerbDelete  = "DELETE"
+	containerSessionVerbSetEACL = "SETEACL"
+)
+
 func (c *sessionTokenContext) UnmarshalJSON(data []byte) (err error) {
 	var m sessionTokenModel
 
@@ -29,11 +35,11 @@ func (c *sessionTokenContext) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	switch m.Verb {
-	case apisession.ContainerVerbPut.String():
+	case containerSessionVerbPut:
 		c.verb = session.VerbContainerPut
-	case apisession.ContainerVerbSetEACL.String():
+	case containerSessionVerbSetEACL:
 		c.verb = session.VerbContainerSetEACL
-	case apisession.ContainerVerbDelete.String():
+	case containerSessionVerbDelete:
 		c.verb = session.VerbContainerDelete
 	default:
 		return fmt.Errorf("unknown container token verb %s", m.Verb)

--- a/authmate/session_tokens_test.go
+++ b/authmate/session_tokens_test.go
@@ -20,17 +20,22 @@ func TestContainerSessionRules(t *testing.T) {
   },
   {
     "verb": "SETEACL"
+  },
+  {
+    "verb": "DELETE",
+    "ContainerID": "6CcWg8LkcbfMUC8pt7wiy5zM1fyS3psNoxgfppcCgig1"
   }
 ]`)
 
 	sessionContext, err := buildContext(jsonRules)
 	require.NoError(t, err)
 
-	require.Len(t, sessionContext, 3)
+	require.Len(t, sessionContext, 4)
 	require.Equal(t, sessionContext[0].verb, session.VerbContainerPut)
 	require.Zero(t, sessionContext[0].containerID)
 	require.Equal(t, sessionContext[1].verb, session.VerbContainerDelete)
 	require.NotNil(t, sessionContext[1].containerID)
 	require.Equal(t, sessionContext[2].verb, session.VerbContainerSetEACL)
 	require.Zero(t, sessionContext[2].containerID)
+	require.Equal(t, sessionContext[1], sessionContext[3])
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.105.1
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240305074711-35bc78d84dc4
 	github.com/nspcc-dev/neofs-contract v0.19.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240326133951-7f940dcb37d8
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240412074628-830a0ff84256
 	github.com/nspcc-dev/tzhash v1.8.0
 	github.com/panjf2000/ants/v2 v2.5.0
 	github.com/prometheus/client_golang v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/minio/sio v0.3.0
 	github.com/nats-io/nats.go v1.31.0
 	github.com/nspcc-dev/neo-go v0.105.1
-	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240305074711-35bc78d84dc4
 	github.com/nspcc-dev/neofs-contract v0.19.1
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240412074628-830a0ff84256
 	github.com/nspcc-dev/tzhash v1.8.0
@@ -36,6 +35,7 @@ require (
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/nspcc-dev/go-ordered-json v0.0.0-20240112074137-296698a162ae // indirect
 	github.com/nspcc-dev/hrw/v2 v2.0.1 // indirect
+	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240305074711-35bc78d84dc4 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240305074711-35bc78d84dc4 h1:ar
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240305074711-35bc78d84dc4/go.mod h1:7Tm1NKEoUVVIUlkVwFrPh7GG5+Lmta2m7EGr4oVpBd8=
 github.com/nspcc-dev/neofs-contract v0.19.1 h1:U1Uh+MlzfkalO0kRJ2pADZyHrmAOroC6KLFjdWnTNR0=
 github.com/nspcc-dev/neofs-contract v0.19.1/go.mod h1:ZOGouuwuHpgvYkx/LCGufGncIzEUhYEO18LL4cWEbyw=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240326133951-7f940dcb37d8 h1:0qr5CEPXp94CRnYyikKu54lJgFLBVJ7Per+zXIBr6tc=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240326133951-7f940dcb37d8/go.mod h1:2XHytVt+AFQkwr6vpcYvdm13mA2rZxB+STrxtwSrtx8=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240412074628-830a0ff84256 h1:z6bkaWW954KuQjzA5cbjL8YF6xlF7nQtesJXvzg309k=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240412074628-830a0ff84256/go.mod h1:2XHytVt+AFQkwr6vpcYvdm13mA2rZxB+STrxtwSrtx8=
 github.com/nspcc-dev/rfc6979 v0.2.1 h1:8wWxkamHWFmO790GsewSoKUSJjVnL1fmdRpokU/RgRM=
 github.com/nspcc-dev/rfc6979 v0.2.1/go.mod h1:Tk7h5kyUWkhjyO3zUgFFhy1v2vQv3BvQEntakdtqrWc=
 github.com/nspcc-dev/tzhash v1.8.0 h1:pJvzME2mZzP/h5rcy/Wb6amT9FJBFeKbJ3HEnWEeUpY=

--- a/internal/neofs/neofs_test.go
+++ b/internal/neofs/neofs_test.go
@@ -121,7 +121,7 @@ func createContainer(ctx context.Context, signer user.Signer, p *pool.Pool) (cid
 
 	var pp netmap.PlacementPolicy
 	pp.SetContainerBackupFactor(1)
-	pp.AddReplicas(rd)
+	pp.SetReplicas([]netmap.ReplicaDescriptor{rd})
 
 	cnr.SetPlacementPolicy(pp)
 	cnr.SetBasicACL(acl.PublicRW)


### PR DESCRIPTION
it's going to be deprecated. Any app should use https://github.com/nspcc-dev/neofs-sdk-go only

* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/570