### PR TITLE
Makefile: Fix `sync-tree`

### DIFF
--- a/syncTree.sh
+++ b/syncTree.sh
@@ -6,7 +6,7 @@ REVISION="feaa9eace7098c343598bf08fb50746a1e8d2deb"
 
 echo "tree service revision ${REVISION}"
 
-FILES=$(curl -s https://github.com/nspcc-dev/neofs-node/tree/${REVISION}/pkg/services/tree | jq | sed -n "s,.*\"pkg/services/tree/\(.*\.pb\.go\)\".*,\1,p")
+FILES=$(curl -s -H "Accept: application/json" https://github.com/nspcc-dev/neofs-node/tree/${REVISION}/pkg/services/tree | jq | sed -n "s,.*\"pkg/services/tree/\(.*\.pb\.go\)\".*,\1,p")
 
 for file in $FILES; do
   if [[ $file == *"neofs"* ]]; then


### PR DESCRIPTION
i tried to fix for #940, and saw a request for a fix within #939 late. We can handle this before or just cherry-pick there, up to you @roman-khimov @smallhive 

in the future, i'd try to switch to using some stable GitHub API ([trees](https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28) or [contents](https://docs.github.com/en/rest/repos/contents))