### PR TITLE
Update ACL structures to have flexible types

### DIFF
--- a/api/handler/json_types.go
+++ b/api/handler/json_types.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"encoding/json"
+)
+
+type (
+	stringOrSlice struct {
+		values []string
+	}
+)
+
+func (s *stringOrSlice) UnmarshalJSON(bytes []byte) error {
+	if err := json.Unmarshal(bytes, &s.values); err == nil {
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(bytes, &str); err != nil {
+		return err
+	}
+
+	s.values = []string{str}
+	return nil
+}
+
+func (s stringOrSlice) MarshalJSON() ([]byte, error) {
+	values := s.values
+	if values == nil {
+		values = []string{}
+	}
+
+	if len(s.values) == 1 {
+		str := s.values[0]
+		return json.Marshal(&str)
+	}
+
+	return json.Marshal(values)
+}

--- a/api/handler/json_types_test.go
+++ b/api/handler/json_types_test.go
@@ -1,0 +1,108 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type (
+	testCase struct {
+		Action stringOrSlice `json:"action"`
+	}
+)
+
+func TestStringOrSlice(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var (
+			payload = []byte(`{"action":"s3:PutObject"}`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Equal(t, []string{"s3:PutObject"}, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+		require.Equal(t, payload, marshaled)
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		var (
+			payload = []byte(`{"action":"*"}`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Equal(t, []string{"*"}, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+		require.Equal(t, payload, marshaled)
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		var (
+			payload = []byte(`{"action":["s3:PutObject","s3:GetObject"]}`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Equal(t, []string{"s3:PutObject", "s3:GetObject"}, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+		require.Equal(t, payload, marshaled)
+	})
+
+	t.Run("single element slice", func(t *testing.T) {
+		var (
+			payload = []byte(`{"action":["s3:PutObject"]}`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Equal(t, []string{"s3:PutObject"}, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+
+		// if only one element, marshalling makes it as a string, not a slice.
+		singleElementPayload := []byte(`{"action":"s3:PutObject"}`)
+		require.Equal(t, singleElementPayload, marshaled)
+	})
+
+	t.Run("single element slice, with spaces", func(t *testing.T) {
+		var (
+			payload = []byte(`{    "action"     :      [     "s3:PutObject"     ]     }`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Equal(t, []string{"s3:PutObject"}, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+
+		// if only one element, marshalling makes it as a string, not a slice.
+		singleElementPayload := []byte(`{"action":"s3:PutObject"}`)
+		require.Equal(t, singleElementPayload, marshaled)
+	})
+
+	t.Run("nil slice", func(t *testing.T) {
+		var (
+			payload = []byte(`{}`)
+			obj     testCase
+		)
+
+		require.NoError(t, json.Unmarshal(payload, &obj))
+		require.Nil(t, obj.Action.values)
+
+		marshaled, err := json.Marshal(obj)
+		require.NoError(t, err)
+
+		singleElementPayload := []byte(`{"action":[]}`)
+		require.Equal(t, singleElementPayload, marshaled)
+	})
+}

--- a/docs/aws_s3_compat.md
+++ b/docs/aws_s3_compat.md
@@ -36,8 +36,37 @@ Reference:
 
 For now there are some limitations:
 * [Bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html) supports only one `Principal` per `Statement`. 
-Principal must be `"AWS": "*"` (to refer all users) or `"CanonicalUser": "0313b1ac3a8076e155a7e797b24f0b650cccad5941ea59d7cfd51a024a8b2a06bf"` (hex encoded public key of desired user).
-* Resource in bucket policy is an array. Each item MUST contain bucket name, CAN contain object name (wildcards are not supported):
+Principal must be `"AWS": "*"` or `"*"` (to refer all users) or `"CanonicalUser": "0313b1ac3a8076e155a7e797b24f0b650cccad5941ea59d7cfd51a024a8b2a06bf"` (hex encoded public key of desired user).
+```json
+{
+  "Statement": [
+    {
+      "Principal": "*"
+    }
+  ]
+}
+```
+```json
+{
+  "Statement": [
+    {
+      "Principal": {
+        "AWS": "*"
+      }
+    }
+  ]
+}
+```
+* Resource in bucket policy is a string value or array of strings. Each item MUST contain bucket name, CAN contain object name (wildcards are not supported):
+```json
+{
+  "Statement": [
+    {
+      "Resource": "arn:aws:s3:::bucket"
+    }
+  ]
+}
+```
 ```json
 {
   "Statement": [
@@ -46,6 +75,26 @@ Principal must be `"AWS": "*"` (to refer all users) or `"CanonicalUser": "0313b1
         "arn:aws:s3:::bucket",
         "arn:aws:s3:::bucket/some/object"
       ]
+    }
+  ]
+}
+
+```
+* Action is a string value or array of strings:
+```json
+{
+  "Statement": [
+    {
+      "Action": "s3:PutObject"
+    }
+  ]
+}
+```
+```json
+{
+  "Statement": [
+    {
+      "Action": ["s3:PutObject", "s3:PutObjectAcl"]
     }
   ]
 }


### PR DESCRIPTION
The PR is not solving test issues completely. It gives the ability to use wildcards in `Principal` and `Action` fields