### PR TITLE
Same versionid for different versions

### DIFF
--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -467,7 +467,18 @@ func (n *layer) objectDelete(ctx context.Context, bktInfo *data.BucketInfo, idOb
 
 	n.cache.DeleteObject(newAddress(bktInfo.CID, idObj))
 
-	return n.neoFS.DeleteObject(ctx, prm)
+	err := n.neoFS.DeleteObject(ctx, prm)
+
+	reqInfo := api.GetReqInfo(ctx)
+	n.log.Debug("delete object",
+		zap.String("reqId", reqInfo.RequestID),
+		zap.String("bucket", bktInfo.Name),
+		zap.Stringer("cid", bktInfo.CID),
+		zap.Stringer("oid", idObj),
+		zap.Error(err),
+	)
+
+	return err
 }
 
 // objectPutAndHash prepare auth parameters and invoke neofs.CreateObject.


### PR DESCRIPTION
I've put the versioning bucket settings check in a separate commit. Do we really want to have this _nonce_ only for the versioning bucket? I consider it possible to have this situation in a regular container as well.

Thus we may merge this commit with the first one or just drop

Closes #986