### PR TITLE
Update default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document outlines major changes between releases.
 
 ### Changed
 - Go 1.22+ is required to build now (#927)
+- stream_timeout default timeout from 10s to 60s (#973)
 
 ### Fixed
 

--- a/config/config.env
+++ b/config/config.env
@@ -58,7 +58,7 @@ S3_GW_PROMETHEUS_ADDRESS=localhost:8086
 # Timeout to connect to a node
 S3_GW_CONNECT_TIMEOUT=10s
 # Timeout for individual operations in streaming RPC.
-S3_GW_STREAM_TIMEOUT=10s
+S3_GW_STREAM_TIMEOUT=60s
 # Timeout to check node health during rebalance.
 S3_GW_HEALTHCHECK_TIMEOUT=15s
 # Interval to check node health

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,7 +65,7 @@ prometheus:
 # Timeout to connect to a node
 connect_timeout: 10s
 # Timeout for individual operations in streaming RPC.
-stream_timeout: 10s
+stream_timeout: 60s
 # Timeout to check node health during rebalance
 healthcheck_timeout: 15s
 # Interval to check node health

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ listen_domains:
 rpc_endpoint: http://morph-chain.neofs.devenv:30333
 
 connect_timeout: 10s
-stream_timeout: 10s
+stream_timeout: 60s
 healthcheck_timeout: 15s
 rebalance_interval: 60s
 pool_error_threshold: 100
@@ -189,18 +189,18 @@ allowed_access_key_id_prefixes:
    - 3stjWenX15YwYzczMr88gy3CQr4NYFBQ8P7keGzH5QFn
 ```
 
-| Parameter                        | Type       | SIGHUP reload | Default value  | Description                                                                                                                                                                                                       |
-|----------------------------------|------------|---------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `listen_domains`                 | `[]string` |               |                | Domains to be able to use virtual-hosted-style access to bucket.                                                                                                                                                  |
-| `rpc_endpoint`                   | `string`   | yes           |                | The address of the RPC host to which the gateway connects to resolve bucket names (required to use the `nns` resolver).                                                                                           |
-| `connect_timeout`                | `duration` |               | `10s`          | Timeout to connect to a node.                                                                                                                                                                                     |
-| `stream_timeout`                 | `duration` |               | `10s`          | Timeout for individual operations in streaming RPC.                                                                                                                                                               |
-| `healthcheck_timeout`            | `duration` |               | `15s`          | Timeout to check node health during rebalance.                                                                                                                                                                    |
-| `rebalance_interval`             | `duration` |               | `60s`          | Interval to check node health.                                                                                                                                                                                    |
-| `pool_error_threshold`           | `uint32`   |               | `100`          | The number of errors on connection after which node is considered as unhealthy.                                                                                                                                   |
-| `max_clients_count`              | `int`      |               | `100`          | Limits for processing of clients' requests.                                                                                                                                                                       |
-| `max_clients_deadline`           | `duration` |               | `30s`          | Deadline after which the gate sends error `RequestTimeout` to a client.                                                                                                                                           |
-| `allowed_access_key_id_prefixes` | `[]string` |               |                | List of allowed `AccessKeyID` prefixes which S3 GW serve. If the parameter is omitted, all `AccessKeyID` will be accepted.                                                                                        |
+| Parameter                        | Type       | SIGHUP reload | Default value | Description                                                                                                                                                                                                       |
+|----------------------------------|------------|---------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `listen_domains`                 | `[]string` |               |               | Domains to be able to use virtual-hosted-style access to bucket.                                                                                                                                                  |
+| `rpc_endpoint`                   | `string`   | yes           |               | The address of the RPC host to which the gateway connects to resolve bucket names (required to use the `nns` resolver).                                                                                           |
+| `connect_timeout`                | `duration` |               | `10s`         | Timeout to connect to a node.                                                                                                                                                                                     |
+| `stream_timeout`                 | `duration` |               | `60s`         | Timeout for individual operations in streaming RPC.                                                                                                                                                               |
+| `healthcheck_timeout`            | `duration` |               | `15s`         | Timeout to check node health during rebalance.                                                                                                                                                                    |
+| `rebalance_interval`             | `duration` |               | `60s`         | Interval to check node health.                                                                                                                                                                                    |
+| `pool_error_threshold`           | `uint32`   |               | `100`         | The number of errors on connection after which node is considered as unhealthy.                                                                                                                                   |
+| `max_clients_count`              | `int`      |               | `100`         | Limits for processing of clients' requests.                                                                                                                                                                       |
+| `max_clients_deadline`           | `duration` |               | `30s`         | Deadline after which the gate sends error `RequestTimeout` to a client.                                                                                                                                           |
+| `allowed_access_key_id_prefixes` | `[]string` |               |               | List of allowed `AccessKeyID` prefixes which S3 GW serve. If the parameter is omitted, all `AccessKeyID` will be accepted.                                                                                        |
 
 ### `wallet` section
 


### PR DESCRIPTION
Closes #973.

Node timeout left as is, 10s. According to the [REST gate](https://github.com/nspcc-dev/neofs-rest-gw/pull/244/files#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bbaR22)