### PR TITLE
golangci: update configuration from org-wide linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,18 @@ linters-settings:
     # 'default' case is present, even if all enum members aren't listed in the
     # switch
     default-signifies-exhaustive: true
+  gofmt:
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/pkg/errors:
+            reason: "Obsolete after the 1.13 release; use the standard `errors` package"
+  revive:
+    rules:
+      - name: duplicated-imports
 
 linters:
   enable:
@@ -32,17 +44,34 @@ linters:
     # some default golangci-lint linters
     - errcheck
     - gosimple
+    - godot
     - ineffassign
     - staticcheck
     - typecheck
     - unused
 
     # extra linters
+    # - goconst
+    # - goerr113
+    # - gomnd
+    # - nonamedreturns
+    # - unparam
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - durationcheck
+    - errorlint
     - exhaustive
-    - godot
     - gofmt
-    - whitespace
     - goimports
+    - gomodguard
+    - intrange
+    - misspell
+    - predeclared
+    - reassign
+    - whitespace
   disable-all: true
   fast: false
 

--- a/api/handler/encryption_test.go
+++ b/api/handler/encryption_test.go
@@ -121,7 +121,7 @@ func equalDataSlices(t *testing.T, expected, actual []byte) {
 		return
 	}
 
-	for i := range len(expected) {
+	for i := range expected {
 		if expected[i] != actual[i] {
 			require.Equalf(t, expected[i], actual[i], "differ start with '%d' position, length: %d", i, len(expected))
 		}


### PR DESCRIPTION
We can't reuse the job at the moment because of the tree service code (#1007), but let's at least grab the best settings we can have now (they don't change often anyway).