### PR TITLE
cmd: disable zap log sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document outlines major changes between releases.
 ### Added
 
 ### Changed
+- Log sampling is disabled now (#1024)
 
 ### Fixed
 

--- a/cmd/s3-gw/app_settings.go
+++ b/cmd/s3-gw/app_settings.go
@@ -407,6 +407,7 @@ func newLogger(v *viper.Viper) *Logger {
 	c := zap.NewProductionConfig()
 	c.Level = zap.NewAtomicLevelAt(lvl)
 	c.Encoding = "console"
+	c.Sampling = nil
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	} else {


### PR DESCRIPTION
Skipping log lines is not safe to be used by default. Notice that s3-authmate doesn't have this problem because of the way it constructs its settings.

See also:
 * https://github.com/nspcc-dev/neofs-node/pull/3011
 * https://github.com/nspcc-dev/neo-go/pull/598