### PR TITLE
Avoid deprecated code and refactor IDs

### DIFF
--- a/api/auth/center.go
+++ b/api/auth/center.go
@@ -132,8 +132,8 @@ func (c *center) parseAuthHeader(header string) (*authHeader, error) {
 }
 
 func (a *authHeader) getAddress() (oid.Address, error) {
-	var addr oid.Address
-	if err := addr.DecodeString(strings.ReplaceAll(a.AccessKeyID, "0", "/")); err != nil {
+	addr, err := oid.DecodeAddressString(strings.ReplaceAll(a.AccessKeyID, "0", "/"))
+	if err != nil {
 		return addr, s3errors.GetAPIError(s3errors.ErrInvalidAccessKeyID)
 	}
 	return addr, nil
@@ -271,8 +271,8 @@ func (c *center) checkFormData(r *http.Request) (*Box, error) {
 		return nil, fmt.Errorf("failed to parse x-amz-date field: %w", err)
 	}
 
-	var addr oid.Address
-	if err = addr.DecodeString(strings.ReplaceAll(submatches["access_key_id"], "0", "/")); err != nil {
+	addr, err := oid.DecodeAddressString(strings.ReplaceAll(submatches["access_key_id"], "0", "/"))
+	if err != nil {
 		return nil, s3errors.GetAPIError(s3errors.ErrInvalidAccessKeyID)
 	}
 

--- a/api/cache/objects_test.go
+++ b/api/cache/objects_test.go
@@ -21,12 +21,10 @@ func getTestConfig() *Config {
 
 func TestCache(t *testing.T) {
 	obj := objecttest.Object()
-	objID, _ := obj.ID()
-	cnrID, _ := obj.ContainerID()
 
 	var addr oid.Address
-	addr.SetContainer(cnrID)
-	addr.SetObject(objID)
+	addr.SetContainer(obj.GetContainerID())
+	addr.SetObject(obj.GetID())
 
 	extObjInfo := &data.ExtendedObjectInfo{
 		ObjectInfo: &data.ObjectInfo{

--- a/api/cache/objects_test.go
+++ b/api/cache/objects_test.go
@@ -22,9 +22,7 @@ func getTestConfig() *Config {
 func TestCache(t *testing.T) {
 	obj := objecttest.Object()
 
-	var addr oid.Address
-	addr.SetContainer(obj.GetContainerID())
-	addr.SetObject(obj.GetID())
+	addr := oid.NewAddress(obj.GetContainerID(), obj.GetID())
 
 	extObjInfo := &data.ExtendedObjectInfo{
 		ObjectInfo: &data.ObjectInfo{

--- a/api/cache/objectslist.go
+++ b/api/cache/objectslist.go
@@ -98,7 +98,7 @@ func (l *ObjectsListCache) CleanCacheEntriesContainingObject(objectName string, 
 				zap.String("expected", fmt.Sprintf("%T", k)))
 			continue
 		}
-		if cnr.Equals(k.cid) && strings.HasPrefix(objectName, k.prefix) {
+		if cnr == k.cid && strings.HasPrefix(objectName, k.prefix) {
 			l.cache.Remove(k)
 		}
 	}

--- a/api/data/info.go
+++ b/api/data/info.go
@@ -141,11 +141,7 @@ func (o *ObjectInfo) NiceName() string { return o.Bucket + "/" + o.Name }
 
 // Address returns object address.
 func (o *ObjectInfo) Address() oid.Address {
-	var addr oid.Address
-	addr.SetContainer(o.CID)
-	addr.SetObject(o.ID)
-
-	return addr
+	return oid.NewAddress(o.CID, o.ID)
 }
 
 func (b BucketSettings) Unversioned() bool {

--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -1001,7 +1001,7 @@ func tryServiceRecord(record eacl.Record) *ServiceRecord {
 	resourceFilter := record.Filters()[0]
 	recordsFilter := record.Filters()[1]
 	if resourceFilter.From() != eacl.HeaderFromService || recordsFilter.From() != eacl.HeaderFromService ||
-		resourceFilter.Matcher() != eacl.MatchUnknown || recordsFilter.Matcher() != eacl.MatchUnknown ||
+		resourceFilter.Matcher() != eacl.MatchUnspecified || recordsFilter.Matcher() != eacl.MatchUnspecified ||
 		resourceFilter.Key() != serviceRecordResourceKey || recordsFilter.Key() != serviceRecordGroupLengthKey {
 		return nil
 	}
@@ -1499,7 +1499,7 @@ func effectToAction(effect string) eacl.Action {
 	case "Deny":
 		return eacl.ActionDeny
 	}
-	return eacl.ActionUnknown
+	return eacl.ActionUnspecified
 }
 
 func actionToEffect(action eacl.Action) string {
@@ -1863,7 +1863,7 @@ func isValidOwnerPreferred(r *http.Request) bool {
 	return cannedACL == cannedACLBucketOwnerFullControl
 }
 
-func updateBucketOwnership(records []eacl.Record, newRecord *eacl.Record) []eacl.Record {
+func updateBucketOwnership(records []eacl.Record, newRecord *eacl.Record) eacl.Table {
 	var (
 		rowID = -1
 	)
@@ -1893,7 +1893,7 @@ func updateBucketOwnership(records []eacl.Record, newRecord *eacl.Record) []eacl
 		records = append(records, *newRecord)
 	}
 
-	return records
+	return eacl.ConstructTable(records)
 }
 
 func isBucketOwnerObjectWriter(table *eacl.Table) bool {

--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -1061,8 +1061,8 @@ func formRecords(resource *astResource) ([]*eacl.Record, error) {
 		}
 
 		if len(resource.Version) != 0 {
-			var id oid.ID
-			if err := id.DecodeString(resource.Version); err != nil {
+			id, err := oid.DecodeString(resource.Version)
+			if err != nil {
 				return nil, fmt.Errorf("parse object version (oid): %w", err)
 			}
 

--- a/api/handler/acl_test.go
+++ b/api/handler/acl_test.go
@@ -37,8 +37,7 @@ func TestTableToAst(t *testing.T) {
 	b := make([]byte, 32)
 	_, err := io.ReadFull(rand.Reader, b)
 	require.NoError(t, err)
-	var id oid.ID
-	id.SetSHA256(sha256.Sum256(b))
+	id := oid.NewFromObjectHeaderBinary(b)
 
 	key, err := keys.NewPrivateKey()
 	require.NoError(t, err)

--- a/api/handler/ownership.go
+++ b/api/handler/ownership.go
@@ -90,12 +90,7 @@ func (h *handler) PutBucketOwnershipControlsHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	var newEACL eacl.Table
-
-	newRecords := updateBucketOwnership(bucketACL.EACL.Records(), rec)
-	for _, record := range newRecords {
-		newEACL.AddRecord(&record)
-	}
+	newEACL := updateBucketOwnership(bucketACL.EACL.Records(), rec)
 
 	p := layer.PutBucketACLParams{
 		BktInfo:      bktInfo,
@@ -188,12 +183,7 @@ func (h *handler) DeleteBucketOwnershipControlsHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	var newEACL eacl.Table
-
-	newRecords := updateBucketOwnership(bucketACL.EACL.Records(), nil)
-	for _, record := range newRecords {
-		newEACL.AddRecord(&record)
-	}
+	newEACL := updateBucketOwnership(bucketACL.EACL.Records(), nil)
 
 	p := layer.PutBucketACLParams{
 		BktInfo:      bktInfo,

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -365,9 +365,9 @@ func (n *layer) Owner(ctx context.Context) user.ID {
 // OwnerPublicKey returns owner public key from BearerToken (context).
 func (n *layer) OwnerPublicKey(ctx context.Context) (*keys.PublicKey, error) {
 	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil && bd.Gate.BearerToken != nil {
-		if len(bd.Gate.BearerToken.SigningKeyBytes()) > 0 {
+		if sig, ok := bd.Gate.BearerToken.Signature(); ok {
 			var pk keys.PublicKey
-			if err := pk.DecodeBytes(bd.Gate.BearerToken.SigningKeyBytes()); err != nil {
+			if err := pk.DecodeBytes(sig.PublicKeyBytes()); err != nil {
 				return nil, fmt.Errorf("pub key decode: %w", err)
 			}
 
@@ -384,7 +384,7 @@ func (n *layer) prepareAuthParameters(ctx context.Context, prm *PrmAuth, bktOwne
 
 func bearerTokenFromContext(ctx context.Context, bktOwner user.ID) *bearer.Token {
 	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil && bd.Gate.BearerToken != nil {
-		if bktOwner.Equals(bd.Gate.BearerToken.ResolveIssuer()) {
+		if bktOwner == bd.Gate.BearerToken.ResolveIssuer() {
 			return bd.Gate.BearerToken
 		}
 	}

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -1033,8 +1033,8 @@ func (n *layer) CreateBucket(ctx context.Context, p *CreateBucketParams) (*data.
 }
 
 func (n *layer) ResolveBucket(ctx context.Context, name string) (cid.ID, error) {
-	var cnrID cid.ID
-	if err := cnrID.DecodeString(name); err != nil {
+	cnrID, err := cid.DecodeString(name)
+	if err != nil {
 		if cnrID, err = n.resolver.ResolveCID(ctx, name); err != nil {
 			return cid.ID{}, err
 		}

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -486,7 +486,7 @@ func (n *layer) uploadZeroPart(ctx context.Context, multipartInfo *data.Multipar
 	var hashlessHeaderObject object.Object
 	hashlessHeaderObject.SetContainerID(bktInfo.CID)
 	hashlessHeaderObject.SetType(object.TypeRegular)
-	hashlessHeaderObject.SetOwnerID(&bktInfo.Owner)
+	hashlessHeaderObject.SetOwner(bktInfo.Owner)
 	hashlessHeaderObject.SetAttributes(attrs...)
 	hashlessHeaderObject.SetCreationEpoch(n.neoFS.CurrentEpoch())
 
@@ -1006,7 +1006,7 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 		return nil, nil, err
 	}
 
-	headerObjectID, _ := header.ID()
+	headerObjectID := header.GetID()
 
 	// the "big object" is not presented in system, but we have to put correct info about it and its version.
 

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -266,7 +266,6 @@ func (n *layer) uploadPart(ctx context.Context, multipartInfo *data.MultipartInf
 
 	var (
 		splitPreviousID oid.ID
-		splitFirstID    oid.ID
 		multipartHash   = sha256.New()
 		tzHash          hash.Hash
 		creationTime    = TimeNow(ctx)
@@ -325,7 +324,8 @@ func (n *layer) uploadPart(ctx context.Context, multipartInfo *data.MultipartInf
 
 	splitPreviousID = lastPart.OID
 
-	if err = splitFirstID.DecodeString(multipartInfo.UploadID); err != nil {
+	splitFirstID, err := oid.DecodeString(multipartInfo.UploadID)
+	if err != nil {
 		return nil, fmt.Errorf("failed to decode multipart upload ID: %w", err)
 	}
 
@@ -823,9 +823,9 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 	var encMultipartObjectSize uint64
 	var lastPartID int
 	var completedPartsHeader strings.Builder
-	var splitFirstID oid.ID
 
-	if err = splitFirstID.DecodeString(multipartInfo.UploadID); err != nil {
+	splitFirstID, err := oid.DecodeString(multipartInfo.UploadID)
+	if err != nil {
 		return nil, nil, fmt.Errorf("decode splitFirstID from UploadID :%w", err)
 	}
 

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -27,7 +27,6 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/s3headers"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
@@ -110,13 +109,6 @@ const (
 	attrS3VersioningState = "S3-versioning-state"
 	attrS3DeleteMarker    = "S3-delete-marker"
 )
-
-func newAddress(cnr cid.ID, obj oid.ID) oid.Address {
-	var addr oid.Address
-	addr.SetContainer(cnr)
-	addr.SetObject(obj)
-	return addr
-}
 
 // objectHead returns all object's headers.
 func (n *layer) objectHead(ctx context.Context, bktInfo *data.BucketInfo, idObj oid.ID) (*object.Object, error) {
@@ -779,7 +771,7 @@ func (n *layer) objectDelete(ctx context.Context, bktInfo *data.BucketInfo, idOb
 
 	n.prepareAuthParameters(ctx, &prm.PrmAuth, bktInfo.Owner)
 
-	n.cache.DeleteObject(newAddress(bktInfo.CID, idObj))
+	n.cache.DeleteObject(oid.NewAddress(bktInfo.CID, idObj))
 
 	err := n.neoFS.DeleteObject(ctx, prm)
 
@@ -1118,7 +1110,7 @@ func (n *layer) objectInfoFromObjectsCacheOrNeoFS(ctx context.Context, bktInfo *
 	}
 
 	owner := n.Owner(ctx)
-	if extInfo := n.cache.GetObject(owner, newAddress(bktInfo.CID, node.OID)); extInfo != nil {
+	if extInfo := n.cache.GetObject(owner, oid.NewAddress(bktInfo.CID, node.OID)); extInfo != nil {
 		return extInfo.ObjectInfo
 	}
 

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -370,7 +370,7 @@ func (n *layer) prepareMultipartHeadObject(ctx context.Context, p *PutObjectPara
 	var headerObject object.Object
 	headerObject.SetContainerID(p.BktInfo.CID)
 	headerObject.SetType(object.TypeRegular)
-	headerObject.SetOwnerID(&owner)
+	headerObject.SetOwner(owner)
 
 	currentVersion := version.Current()
 	headerObject.SetVersion(&currentVersion)

--- a/api/layer/util.go
+++ b/api/layer/util.go
@@ -90,7 +90,7 @@ func objectInfoFromMeta(bkt *data.BucketInfo, meta *object.Object) *data.ObjectI
 	attributes := userHeaders(meta.Attributes())
 	customHeaders, mimeType, creation := extractHeaders(attributes)
 
-	objID, _ := meta.ID()
+	objID := meta.GetID()
 	payloadChecksum, _ := meta.PayloadChecksum()
 
 	var versionID = data.UnversionedObjectVersionID
@@ -108,7 +108,7 @@ func objectInfoFromMeta(bkt *data.BucketInfo, meta *object.Object) *data.ObjectI
 		Created:        creation,
 		ContentType:    mimeType,
 		Headers:        customHeaders,
-		Owner:          *meta.OwnerID(),
+		Owner:          meta.Owner(),
 		OwnerPublicKey: bkt.OwnerPublicKey,
 		Size:           int64(meta.PayloadSize()),
 		HashSum:        hex.EncodeToString(payloadChecksum.Value()),
@@ -144,8 +144,7 @@ func filepathFromObject(o *object.Object) string {
 			return attr.Value()
 		}
 	}
-	objID, _ := o.ID()
-	return objID.EncodeToString()
+	return o.GetID().EncodeToString()
 }
 
 // NameFromString splits name into a base file name and a directory path.

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -114,8 +114,7 @@ func (tc *testContext) checkListObjects(ids ...oid.ID) {
 
 func (tc *testContext) getObjectByID(objID oid.ID) *object.Object {
 	for _, obj := range tc.testNeoFS.Objects() {
-		id, _ := obj.ID()
-		if id.Equals(objID) {
+		if obj.GetID() == objID {
 			return obj
 		}
 	}

--- a/authmate/authmate.go
+++ b/authmate/authmate.go
@@ -152,7 +152,7 @@ type (
 )
 
 func (a *Agent) checkContainer(ctx context.Context, opts ContainerOptions, idOwner user.ID, ownerPubKey keys.PublicKey) (cid.ID, error) {
-	if !opts.ID.Equals(cid.ID{}) {
+	if !opts.ID.IsZero() {
 		return opts.ID, a.neoFS.ContainerExists(ctx, opts.ID)
 	}
 
@@ -360,12 +360,9 @@ func restrictedRecords() (records []*eacl.Record) {
 func buildBearerToken(key *keys.PrivateKey, table *eacl.Table, lifetime lifetimeOptions, gateKey *keys.PublicKey) (*bearer.Token, error) {
 	signer := user.NewAutoIDSignerRFC6979(key.PrivateKey)
 
-	var ownerID user.ID
-	ownerID.SetScriptHash(gateKey.GetScriptHash())
-
 	var bearerToken bearer.Token
 	bearerToken.SetEACLTable(*table)
-	bearerToken.ForUser(ownerID)
+	bearerToken.ForUser(user.NewFromScriptHash(gateKey.GetScriptHash()))
 	bearerToken.SetExp(lifetime.Exp)
 	bearerToken.SetIat(lifetime.Iat)
 	bearerToken.SetNbf(lifetime.Iat)

--- a/authmate/authmate.go
+++ b/authmate/authmate.go
@@ -304,8 +304,8 @@ func (a *Agent) IssueSecret(ctx context.Context, w io.Writer, options *IssueSecr
 func (a *Agent) ObtainSecret(ctx context.Context, options *ObtainSecretOptions) (*ObtainingResult, error) {
 	bearerCreds := tokens.New(a.neoFS, options.GatePrivateKey, cache.DefaultAccessBoxConfig(a.log))
 
-	var addr oid.Address
-	if err := addr.DecodeString(options.SecretAddress); err != nil {
+	addr, err := oid.DecodeAddressString(options.SecretAddress)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse secret address: %w", err)
 	}
 

--- a/creds/tokens/credentials.go
+++ b/creds/tokens/credentials.go
@@ -139,9 +139,5 @@ func (c *cred) Put(ctx context.Context, idCnr cid.ID, issuer user.ID, box *acces
 		return oid.Address{}, fmt.Errorf("create object: %w", err)
 	}
 
-	var addr oid.Address
-	addr.SetObject(idObj)
-	addr.SetContainer(idCnr)
-
-	return addr, nil
+	return oid.NewAddress(idCnr, idObj), nil
 }

--- a/internal/neofs/neofs_test.go
+++ b/internal/neofs/neofs_test.go
@@ -260,7 +260,7 @@ func TestObjectNonce(t *testing.T) {
 		require.NoError(t, err)
 
 		obj.SetContainerID(cnrID)
-		obj.SetOwnerID(&uid)
+		obj.SetOwner(uid)
 		obj.SetPayloadSize(uint64(len(payload)))
 		obj.SetPayload(payload)
 

--- a/internal/neofs/tree.go
+++ b/internal/neofs/tree.go
@@ -900,7 +900,7 @@ func handleError(msg string, err error) error {
 func getBearer(ctx context.Context, bktInfo *data.BucketInfo) []byte {
 	if bd, ok := ctx.Value(api.BoxData).(*accessbox.Box); ok && bd != nil && bd.Gate != nil {
 		if bd.Gate.BearerToken != nil {
-			if bktInfo.Owner.Equals(bd.Gate.BearerToken.ResolveIssuer()) {
+			if bktInfo.Owner == bd.Gate.BearerToken.ResolveIssuer() {
 				return bd.Gate.BearerToken.Marshal()
 			}
 		}


### PR DESCRIPTION
im exploring how [migration](https://github.com/nspcc-dev/neofs-api/issues/305) to N3 accounts gonna affect S3 gw. Some crypto-related SDK elements will be deprecated. Suddenly discovered that earlier places were not removed, so decided to fix them