### PR TITLE
Enable metrics properly

### DIFF
--- a/cmd/s3-gw/app.go
+++ b/cmd/s3-gw/app.go
@@ -423,6 +423,7 @@ func newAppMetrics(logger *zap.Logger, provider GateMetricsCollector, enabled bo
 	return &appMetrics{
 		logger:   logger,
 		provider: provider,
+		enabled:  enabled,
 	}
 }
 


### PR DESCRIPTION
Refs #1079.

It enables neofs_s3_gw_state_health metric.