### PR TITLE
layer: drop S3-ObjectVersion, fix #1188

### DIFF
--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -526,7 +526,7 @@ func (n *layer) comprehensiveSearchAllVersionsInNeoFS(ctx context.Context, bkt *
 			s3headers.AttributeVersioningState,
 			s3headers.AttributeDeleteMarker,
 			s3headers.MetaType,
-			s3headers.AttributeObjectVersion,
+			object.AttributeAssociatedObject,
 			object.AttributeExpirationEpoch,
 			s3headers.AttributeLockMeta,
 		}
@@ -678,7 +678,7 @@ func (n *layer) searchTagsAndLocksInNeoFS(ctx context.Context, bkt *data.BucketI
 		filters.AddFilter(object.AttributeFilePath, "", object.MatchCommonPrefix)
 	}
 
-	filters.AddFilter(s3headers.AttributeObjectVersion, objectVersion, object.MatchStringEqual)
+	filters.AddFilter(object.AttributeAssociatedObject, objectVersion, object.MatchStringEqual)
 
 	searchResultItems, err := n.neoFS.SearchObjectsV2(ctx, bkt.CID, filters, returningAttributes, opts)
 	if err != nil {
@@ -1432,7 +1432,7 @@ func (n *layer) DeleteObjectMetaFiles(ctx context.Context, p *ObjectVersion) err
 	fs.AddFilter(s3headers.MetaType, "", object.MatchStringNotEqual)
 	fs.AddTypeFilter(object.MatchStringEqual, object.TypeRegular)
 	if p.VersionID != "" {
-		fs.AddFilter(s3headers.AttributeObjectVersion, p.VersionID, object.MatchStringEqual)
+		fs.AddFilter(object.AttributeAssociatedObject, p.VersionID, object.MatchStringEqual)
 	}
 
 	var opts client.SearchObjectsOptions

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -121,7 +121,7 @@ func (n *layer) getLockDataFromObjects(ctx context.Context, bkt *data.BucketInfo
 	filters.AddFilter(object.AttributeFilePath, objectName, object.MatchStringEqual)
 	filters.AddTypeFilter(object.MatchStringEqual, object.TypeLock)
 	if version != "" {
-		filters.AddFilter(s3headers.AttributeObjectVersion, version, object.MatchStringEqual)
+		filters.AddFilter(object.AttributeAssociatedObject, version, object.MatchStringEqual)
 	}
 
 	searchResultItems, err := n.neoFS.SearchObjectsV2(ctx, bkt.CID, filters, returningAttributes, opts)
@@ -203,7 +203,6 @@ func (n *layer) putLockObject(ctx context.Context, bktInfo *data.BucketInfo, obj
 	}
 
 	if objectVersion != "" {
-		prm.Attributes[s3headers.AttributeObjectVersion] = objectVersion
 		prm.Attributes[s3headers.AttributeVersioningState] = data.VersioningEnabled
 	}
 

--- a/api/s3headers/headers.go
+++ b/api/s3headers/headers.go
@@ -63,8 +63,7 @@ const (
 	// BucketSettingsMetaVersion contains version of bucket settings file.
 	BucketSettingsMetaVersion = bucketSettingsPrefix + "MetaVersion"
 
-	AttributeObjectVersion = attributePrefix + "ObjectVersion"
-	AttributeObjectNonce   = "__NEOFS__NONCE"
+	AttributeObjectNonce = "__NEOFS__NONCE"
 
 	// Result: S3-Lock-Meta.
 	AttributeLockMeta = attributePrefix + "Lock-Meta"

--- a/docs/attribute_mapping.md
+++ b/docs/attribute_mapping.md
@@ -166,12 +166,10 @@ Indicates whether bucket versioning is enabled.
 
 Specifies the version of the bucket settings object's file structure
 
-### `S3-ObjectVersion`
+### `__NEOFS__ASSOCIATE`
 
-If bucket versioning is enabled, this attribute indicates which version the object belongs to.
-
-The [tag meta object](#tags-object) includes this header for both versioned and unversioned containers.
-It indicates which object the tags are associated with.
+Used for auxiliary objects like tags and locks, indicates which original object
+is tagged or locked (both in versioned and unversioned buckets).
 
 ### `S3-Lock-Meta`
 
@@ -233,7 +231,7 @@ contents for NeoFS lock objects.
 
 **Attributes:**
 
-- `S3-ObjectVersion`
+- `__NEOFS__ASSOCIATE`
 - `S3-Meta-VersioningState`
 - `S3-Lock-Meta`
 
@@ -253,7 +251,7 @@ the original object's attributes.
 **Attributes:**
 
 - `S3-MetaType: tags`
-- `S3-ObjectVersion`
+- `__NEOFS__ASSOCIATE`
 
 ### Bucket Tags Object
 


### PR DESCRIPTION
Locks don't need it since 205357df2c7b002e8a1195b6cdea7527f4859584, now tags can also reus __NEOFS__ASSOCIATE.