### PR TITLE
neofs: EpochDuration is seconds since API 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document outlines major changes between releases.
 ### Changed
 
 ### Fixed
+- Incorrect EpochDuration processing wrt API 2.18 leading to improper expiration calculations (#1193)
 
 ### Updated
 

--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -112,12 +112,8 @@ func (x *NeoFS) TimeToEpoch(ctx context.Context, now, futureTime time.Time) (uin
 	}
 
 	curr := networkInfo.CurrentEpoch()
-	msPerEpoch := durEpoch * uint64(networkInfo.MsPerBlock())
 
-	epochLifetime := uint64(dur.Milliseconds()) / msPerEpoch
-	if uint64(dur.Milliseconds())%msPerEpoch != 0 {
-		epochLifetime++
-	}
+	epochLifetime := (uint64(dur.Seconds()) + durEpoch - 1) / durEpoch
 
 	var epoch uint64
 	if epochLifetime >= math.MaxUint64-curr {


### PR DESCRIPTION
Similar to https://github.com/nspcc-dev/neofs-rest-gw/pull/313. See https://github.com/nspcc-dev/neofs-api/pull/331.