### PR TITLE
Store object version for each lock object

### DIFF
--- a/api/handler/locking.go
+++ b/api/handler/locking.go
@@ -153,13 +153,7 @@ func (h *handler) PutObjectLegalHoldHandler(w http.ResponseWriter, r *http.Reque
 		CopiesNumber: h.cfg.CopiesNumber,
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	if settings.VersioningEnabled() && p.ObjVersion.VersionID == "" {
+	if p.ObjVersion.VersionID == "" {
 		shortInfoParams := &layer.ShortInfoParams{
 			Owner:  bktInfo.Owner,
 			CID:    bktInfo.CID,


### PR DESCRIPTION
It is used to properly utilization of object.AttributeAssociatedObject attribute.

It is an accompaniment for https://github.com/nspcc-dev/neofs-testcases/pull/1123