### PR TITLE
s3-tests: upgrade NeoFS and NeoGo

### DIFF
--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -68,7 +68,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.45.0'
+          version: 'tags/v0.48.1'
           file: 'neofs-cli-linux-amd64'
           target: 's3-tests/neofs-cli'
 
@@ -76,7 +76,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.45.0'
+          version: 'tags/v0.48.1'
           file: 'neofs-adm-linux-amd64'
           target: 's3-tests/neofs-adm'
 
@@ -84,7 +84,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.45.0'
+          version: 'tags/v0.48.1'
           file: 'neofs-ir-linux-amd64'
           target: 's3-tests/neofs-ir'
 
@@ -92,7 +92,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.45.0'
+          version: 'tags/v0.48.1'
           file: 'neofs-lens-linux-amd64'
           target: 's3-tests/neofs-lens'
 
@@ -100,7 +100,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.45.0'
+          version: 'tags/v0.48.1'
           file: 'neofs-node-linux-amd64'
           target: 's3-tests/neofs-node'
 
@@ -108,7 +108,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neo-go'
-          version: 'tags/v0.108.1'
+          version: 'tags/v0.111.0'
           file: 'neo-go-linux-amd64'
           target: 's3-tests/neo-go'
 


### PR DESCRIPTION
Use proper latest versions, current s3-tests requires 0.48.0+