### PR TITLE
layer: don't try to delete subsequent objects if context expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document outlines major changes between releases.
 ### Changed
 
 ### Fixed
+- Context cancellation in DeleteMultipleObjects handler leading to pool client status issues (#1212)
 
 ### Updated
 


### PR DESCRIPTION
This only makes pool go wild with error counts/health checks.