### PR TITLE
Update env variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,7 +502,7 @@ placement_policy:
 
 Make sure you update the config accordingly:
 If you configure application using environment variables change:
-* `S3_GW_DEFAULT_POLICY` -> `S3_GW_PLACEMENT_POLICY_DEFAULT_POLICY`
+* `S3_GW_DEFAULT_POLICY` -> `S3_GW_PLACEMENT_POLICY_DEFAULT`
 * `S3_GW_LISTEN_ADDRESS` -> `S3_GW_SERVER_0_ADDRESS`
 * `S3_GW_TLS_CERT_FILE` -> `S3_GW_SERVER_0_TLS_CERT_FILE` (and set `S3_GW_SERVER_0_TLS_ENABLED=true`)
 * `S3_GW_TLS_KEY_FILE` -> `S3_GW_SERVER_0_TLS_KEY_FILE` (and set `S3_GW_SERVER_0_TLS_ENABLED=true`)

--- a/config/config.env
+++ b/config/config.env
@@ -111,7 +111,7 @@ S3_GW_NATS_ROOT_CA=/path/to/ca
 # Default policy of placing containers in NeoFS
 # If a user sends a request `CreateBucket` and doesn't define policy for placing of a container in NeoFS, the S3 Gateway
 # will put the container with default policy. It can be specified via environment variable, e.g.:
-S3_GW_PLACEMENT_POLICY_DEFAULT_POLICY="REP 3"
+S3_GW_PLACEMENT_POLICY_DEFAULT=REP 3
 # Region to placement policy mapping json file.
 # Path to container policy mapping. The same as '--container-policy' flag for authmate
 S3_GW_PLACEMENT_POLICY_REGION_MAPPING=/path/to/container/policy.json


### PR DESCRIPTION
Using the default policy definition without quotes is mandatory. Otherwise it has excess quotes in the code and parse fails.