### PR TITLE
.git: adjust s3 tests workflow

### DIFF
--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -58,9 +58,9 @@ jobs:
       - run: go version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - run: python --version
 
       - name: Checkout neofs-s3-gw repository
@@ -111,7 +111,7 @@ jobs:
         run: |
           git submodule init
           git submodule update
-          python3.12 -m venv virtualenv
+          python3.13 -m venv virtualenv
           source virtualenv/bin/activate
           pip3 install --upgrade pip
           pip3 install -r neofs-testcases/requirements.txt


### PR DESCRIPTION
need to use dependencies from neofs-testcases in addition to s3-tests specific ones.