### PR TITLE
Drop settings meta objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document outlines major changes between releases.
 
 ### Removed
 - Support for legacy access boxes carrying session token v1 and bearer tokens (#1271)
+- Backward-compatibility code for legacy bucket settings, CORS, tags and notification meta objects (#1265)
 
 ### Upgrading from 0.44.0
 

--- a/api/cache/cache_test.go
+++ b/api/cache/cache_test.go
@@ -137,60 +137,6 @@ func TestObjectInfoCacheType(t *testing.T) {
 	assertInvalidCacheEntry(t, cache.GetObject(key), observedLog)
 }
 
-func TestCORsCacheType(t *testing.T) {
-	logger, observedLog := getObservedLogger()
-	cache := NewSystemCache(DefaultSystemConfig(logger))
-
-	key := "key"
-	cors := &data.CORSConfiguration{}
-
-	err := cache.PutCORS(key, cors)
-	require.NoError(t, err)
-	val := cache.GetCORS(key)
-	require.Equal(t, cors, val)
-	require.Equal(t, 0, observedLog.Len())
-
-	err = cache.cache.Set(key, "tmp")
-	require.NoError(t, err)
-	assertInvalidCacheEntry(t, cache.GetCORS(key), observedLog)
-}
-
-func TestSettingsCacheType(t *testing.T) {
-	logger, observedLog := getObservedLogger()
-	cache := NewSystemCache(DefaultSystemConfig(logger))
-
-	key := "key"
-	settings := &data.BucketSettings{Versioning: data.VersioningEnabled}
-
-	err := cache.PutSettings(key, settings)
-	require.NoError(t, err)
-	val := cache.GetSettings(key)
-	require.Equal(t, settings, val)
-	require.Equal(t, 0, observedLog.Len())
-
-	err = cache.cache.Set(key, "tmp")
-	require.NoError(t, err)
-	assertInvalidCacheEntry(t, cache.GetSettings(key), observedLog)
-}
-
-func TestNotificationConfigurationCacheType(t *testing.T) {
-	logger, observedLog := getObservedLogger()
-	cache := NewSystemCache(DefaultSystemConfig(logger))
-
-	key := "key"
-	notificationConfig := &data.NotificationConfiguration{}
-
-	err := cache.PutNotificationConfiguration(key, notificationConfig)
-	require.NoError(t, err)
-	val := cache.GetNotificationConfiguration(key)
-	require.Equal(t, notificationConfig, val)
-	require.Equal(t, 0, observedLog.Len())
-
-	err = cache.cache.Set(key, "tmp")
-	require.NoError(t, err)
-	assertInvalidCacheEntry(t, cache.GetNotificationConfiguration(key), observedLog)
-}
-
 func assertInvalidCacheEntry(t *testing.T, val any, observedLog *observer.ObservedLogs) {
 	require.Nil(t, val)
 	require.Equal(t, 1, observedLog.Len())

--- a/api/cache/system.go
+++ b/api/cache/system.go
@@ -71,54 +71,6 @@ func (o *SystemCache) GetLockInfo(key string) *data.LockInfo {
 	return result
 }
 
-func (o *SystemCache) GetCORS(key string) *data.CORSConfiguration {
-	entry, err := o.cache.Get(key)
-	if err != nil {
-		return nil
-	}
-
-	result, ok := entry.(*data.CORSConfiguration)
-	if !ok {
-		o.logger.Warn("invalid cache entry type", zap.String("actual", fmt.Sprintf("%T", entry)),
-			zap.String("expected", fmt.Sprintf("%T", result)))
-		return nil
-	}
-
-	return result
-}
-
-func (o *SystemCache) GetSettings(key string) *data.BucketSettings {
-	entry, err := o.cache.Get(key)
-	if err != nil {
-		return nil
-	}
-
-	result, ok := entry.(*data.BucketSettings)
-	if !ok {
-		o.logger.Warn("invalid cache entry type", zap.String("actual", fmt.Sprintf("%T", entry)),
-			zap.String("expected", fmt.Sprintf("%T", result)))
-		return nil
-	}
-
-	return result
-}
-
-func (o *SystemCache) GetNotificationConfiguration(key string) *data.NotificationConfiguration {
-	entry, err := o.cache.Get(key)
-	if err != nil {
-		return nil
-	}
-
-	result, ok := entry.(*data.NotificationConfiguration)
-	if !ok {
-		o.logger.Warn("invalid cache entry type", zap.String("actual", fmt.Sprintf("%T", entry)),
-			zap.String("expected", fmt.Sprintf("%T", result)))
-		return nil
-	}
-
-	return result
-}
-
 // GetTagging returns tags of a bucket or an object.
 func (o *SystemCache) GetTagging(key string) map[string]string {
 	entry, err := o.cache.Get(key)
@@ -142,18 +94,6 @@ func (o *SystemCache) PutObject(key string, obj *data.ObjectInfo) error {
 // PutLockInfo puts an object to cache.
 func (o *SystemCache) PutLockInfo(key string, lockInfo *data.LockInfo) error {
 	return o.cache.Set(key, lockInfo)
-}
-
-func (o *SystemCache) PutCORS(key string, obj *data.CORSConfiguration) error {
-	return o.cache.Set(key, obj)
-}
-
-func (o *SystemCache) PutSettings(key string, settings *data.BucketSettings) error {
-	return o.cache.Set(key, settings)
-}
-
-func (o *SystemCache) PutNotificationConfiguration(key string, obj *data.NotificationConfiguration) error {
-	return o.cache.Set(key, obj)
 }
 
 // PutTagging puts tags of a bucket or an object.

--- a/api/data/info.go
+++ b/api/data/info.go
@@ -10,16 +10,9 @@ import (
 )
 
 const (
-	bktSettingsObject                  = ".s3-settings"
-	bktCORSConfigurationObject         = ".s3-cors"
-	bktNotificationConfigurationObject = ".s3-notifications"
-
 	VersioningUnversioned = "Unversioned"
 	VersioningEnabled     = "Enabled"
 	VersioningSuspended   = "Suspended"
-
-	// BucketSettingsV1 describes v1 version identifier for the bucket settings file.
-	BucketSettingsV1 = "1"
 )
 
 const (
@@ -123,16 +116,6 @@ func NotificationInfoFromObject(objInfo *ObjectInfo) *NotificationInfo {
 		Size:    objInfo.Size,
 		HashSum: objInfo.HashSum,
 	}
-}
-
-// SettingsObjectName is a system name for a bucket settings file.
-func (b *BucketInfo) SettingsObjectName() string { return bktSettingsObject }
-
-// CORSObjectName returns a system name for a bucket CORS configuration file.
-func (b *BucketInfo) CORSObjectName() string { return bktCORSConfigurationObject }
-
-func (b *BucketInfo) NotificationConfigurationObjectName() string {
-	return bktNotificationConfigurationObject
 }
 
 // VersionID returns object version from ObjectInfo.

--- a/api/data/info.go
+++ b/api/data/info.go
@@ -1,7 +1,9 @@
 package data
 
 import (
+	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"time"
 
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -45,6 +47,10 @@ type (
 		AttributeTags          string
 		AttributeSettings      string
 		AttributeNotifications string
+		Settings               *BucketSettings
+		CORS                   *CORSConfiguration
+		Tags                   map[string]string
+		Notifications          *NotificationConfiguration
 	}
 
 	// ObjectInfo holds S3 object data.
@@ -139,4 +145,44 @@ func (b BucketSettings) VersioningEnabled() bool {
 
 func (b BucketSettings) VersioningSuspended() bool {
 	return b.Versioning == VersioningSuspended
+}
+
+// ParseSettings parses the container attributes into Settings, CORS, Tags and Notifications.
+func (b *BucketInfo) ParseSettings() error {
+	b.Settings = &BucketSettings{Versioning: VersioningUnversioned}
+	b.Notifications = &NotificationConfiguration{}
+
+	if b.AttributeSettings != "" {
+		settings := &BucketSettings{Versioning: VersioningUnversioned}
+		if err := json.Unmarshal([]byte(b.AttributeSettings), settings); err != nil {
+			return fmt.Errorf("malformed bucket settings: %w", err)
+		}
+		b.Settings = settings
+	}
+
+	if b.AttributeCors != "" {
+		var corsRules []CORSRule
+		if err := json.Unmarshal([]byte(b.AttributeCors), &corsRules); err != nil {
+			return fmt.Errorf("malformed bucket CORS: %w", err)
+		}
+		b.CORS = &CORSConfiguration{CORSRules: corsRules}
+	}
+
+	if b.AttributeTags != "" {
+		var tags map[string]string
+		if err := json.Unmarshal([]byte(b.AttributeTags), &tags); err != nil {
+			return fmt.Errorf("malformed bucket tags: %w", err)
+		}
+		b.Tags = tags
+	}
+
+	if b.AttributeNotifications != "" {
+		conf := &NotificationConfiguration{}
+		if err := json.Unmarshal([]byte(b.AttributeNotifications), conf); err != nil {
+			return fmt.Errorf("malformed bucket notifications: %w", err)
+		}
+		b.Notifications = conf
+	}
+
+	return nil
 }

--- a/api/handler/acl.go
+++ b/api/handler/acl.go
@@ -297,13 +297,7 @@ func (h *handler) PutBucketACLHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	if settings.BucketOwner == data.BucketOwnerEnforced {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 		if !isValidOwnerEnforced(r) {
 			h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 			return
@@ -428,13 +422,7 @@ func (h *handler) PutObjectACLHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	if settings.BucketOwner == data.BucketOwnerEnforced {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 		if !isValidOwnerEnforced(r) {
 			h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 			return
@@ -442,7 +430,7 @@ func (h *handler) PutObjectACLHandler(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set(api.AmzACL, "")
 	}
 
-	if settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
 		if !isValidOwnerPreferred(r) {
 			h.logAndSendError(w, "header x-amz-acl:bucket-owner-full-control must be set", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied))
 			return
@@ -584,17 +572,12 @@ func (h *handler) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	if index >= 0 {
-		settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-		if err != nil {
-			h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-			return
-		}
-
-		settings.BucketOwner = data.BucketOwnerPreferredAndRestricted
+		newSettings := *bktInfo.Settings
+		newSettings.BucketOwner = data.BucketOwnerPreferredAndRestricted
 
 		p := layer.PutSettingsParams{
 			BktInfo:  bktInfo,
-			Settings: settings,
+			Settings: &newSettings,
 		}
 
 		if err = h.obj.PutBucketSettings(r.Context(), &p); err != nil {

--- a/api/handler/attributes.go
+++ b/api/handler/attributes.go
@@ -116,12 +116,6 @@ func (h *handler) GetObjectAttributesHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	params.MultipartPartsGetter = func(ctx context.Context) ([]object.MeasuredObject, string, error) {
 		return h.obj.GetMultipartParts(ctx, bktInfo, info.ID)
 	}
@@ -132,7 +126,7 @@ func (h *handler) GetObjectAttributesHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	writeAttributesHeaders(w.Header(), extendedInfo, bktSettings.Unversioned())
+	writeAttributesHeaders(w.Header(), extendedInfo, bktInfo.Settings.Unversioned())
 	if err = api.EncodeToResponse(w, response); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}

--- a/api/handler/copy.go
+++ b/api/handler/copy.go
@@ -79,13 +79,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settingsSrc, err := h.obj.GetBucketSettings(r.Context(), srcObjPrm.BktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	if settingsSrc.VersioningEnabled() && srcObjPrm.VersionID == "" {
+	if srcObjPrm.BktInfo.Settings.VersioningEnabled() && srcObjPrm.VersionID == "" {
 		shortInfoParams := &layer.ShortInfoParams{
 			Owner:  srcObjPrm.BktInfo.Owner,
 			CID:    srcObjPrm.BktInfo.CID,
@@ -117,14 +111,8 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), dstBktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	if containsACL {
-		if settings.BucketOwner == data.BucketOwnerEnforced {
+		if dstBktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 			if !isValidOwnerEnforced(r) {
 				h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 				return
@@ -138,7 +126,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
+	if dstBktInfo.Settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
 		if !isValidOwnerPreferred(r) {
 			h.logAndSendError(w, "header x-amz-acl:bucket-owner-full-control must be set", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied))
 			return
@@ -159,7 +147,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if isCopyingToItselfForbidden(reqInfo, srcBucket, srcObject, settings, args) {
+	if isCopyingToItselfForbidden(reqInfo, srcBucket, srcObject, dstBktInfo.Settings, args) {
 		h.logAndSendError(w, "copying to itself without changing anything", reqInfo, s3errors.GetAPIError(s3errors.ErrInvalidCopyDest))
 		return
 	}
@@ -225,7 +213,7 @@ func (h *handler) CopyObjectHandler(w http.ResponseWriter, r *http.Request) {
 		Encryption: encryptionParams,
 	}
 
-	params.Lock, err = formObjectLock(r.Context(), dstBktInfo, settings.LockConfiguration, r.Header)
+	params.Lock, err = formObjectLock(r.Context(), dstBktInfo, dstBktInfo.Settings.LockConfiguration, r.Header)
 	if err != nil {
 		h.logAndSendError(w, "could not form object lock", reqInfo, err)
 		return

--- a/api/handler/delete.go
+++ b/api/handler/delete.go
@@ -72,16 +72,10 @@ func (h *handler) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	p := &layer.DeleteObjectParams{
 		BktInfo:  bktInfo,
 		Objects:  versionedObject,
-		Settings: bktSettings,
+		Settings: bktInfo.Settings,
 	}
 	deletedObjects := h.obj.DeleteObjects(r.Context(), p)
 	deletedObject := deletedObjects[0]
@@ -96,7 +90,7 @@ func (h *handler) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	var m *SendNotificationParams
 
-	if bktSettings.VersioningEnabled() && len(versionID) == 0 {
+	if bktInfo.Settings.VersioningEnabled() && len(versionID) == 0 {
 		m = &SendNotificationParams{
 			Event: EventObjectRemovedDeleteMarkerCreated,
 			NotificationInfo: &data.NotificationInfo{
@@ -200,12 +194,6 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	marshaler := zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
 		for _, obj := range toRemove {
 			encoder.AppendString(obj.String())
@@ -216,7 +204,7 @@ func (h *handler) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *http.Re
 	p := &layer.DeleteObjectParams{
 		BktInfo:  bktInfo,
 		Objects:  toRemove,
-		Settings: bktSettings,
+		Settings: bktInfo.Settings,
 	}
 	deletedObjects := h.obj.DeleteObjects(r.Context(), p)
 

--- a/api/handler/delete_test.go
+++ b/api/handler/delete_test.go
@@ -254,9 +254,11 @@ func createBucketAndObject(tc *handlerContext, bktName, objName string) (*data.B
 
 func createVersionedBucketAndObject(t *testing.T, tc *handlerContext, bktName, objName string) (*data.BucketInfo, *data.ObjectInfo) {
 	createTestBucket(tc, bktName)
+	putBucketVersioning(t, tc, bktName, true)
+
+	// Writing invalidates the cached settings, we need to get refreshed.
 	bktInfo, err := tc.Layer().GetBucketInfo(tc.Context(), bktName)
 	require.NoError(t, err)
-	putBucketVersioning(t, tc, bktName, true)
 
 	objInfo := createTestObject(tc, bktInfo, objName)
 

--- a/api/handler/get.go
+++ b/api/handler/get.go
@@ -132,17 +132,11 @@ func (h *handler) GetObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	p := &layer.HeadObjectParams{
 		BktInfo:                   bktInfo,
 		Object:                    reqInfo.ObjectName,
 		VersionID:                 reqInfo.URL.Query().Get(api.QueryVersionID),
-		IsBucketVersioningEnabled: bktSettings.VersioningEnabled(),
+		IsBucketVersioningEnabled: bktInfo.Settings.VersioningEnabled(),
 	}
 
 	comprehensiveObjectInfo, err := h.obj.ComprehensiveObjectInfo(r.Context(), p)
@@ -253,7 +247,7 @@ func (h *handler) GetObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeHeaders(w.Header(), r.Header, info, len(comprehensiveObjectInfo.TagSet), bktSettings.Unversioned())
+	writeHeaders(w.Header(), r.Header, info, len(comprehensiveObjectInfo.TagSet), bktInfo.Settings.Unversioned())
 	if params != nil {
 		writeRangeHeaders(w, params, info.Size)
 	} else {

--- a/api/handler/handlers_test.go
+++ b/api/handler/handlers_test.go
@@ -191,6 +191,10 @@ func createTestBucketWithLock(hc *handlerContext, bktName string, conf *data.Obj
 	err = hc.Layer().PutBucketSettings(hc.Context(), sp)
 	require.NoError(hc.t, err)
 
+	// Writing invalidates the cached settings, we need to get refreshed.
+	bktInfo, err = hc.Layer().GetBucketInfo(hc.Context(), bktName)
+	require.NoError(hc.t, err)
+
 	return bktInfo
 }
 

--- a/api/handler/head.go
+++ b/api/handler/head.go
@@ -39,17 +39,11 @@ func (h *handler) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	p := &layer.HeadObjectParams{
 		BktInfo:                   bktInfo,
 		Object:                    reqInfo.ObjectName,
 		VersionID:                 reqInfo.URL.Query().Get(api.QueryVersionID),
-		IsBucketVersioningEnabled: bktSettings.VersioningEnabled(),
+		IsBucketVersioningEnabled: bktInfo.Settings.VersioningEnabled(),
 	}
 
 	comprehensiveInfo, err := h.obj.ComprehensiveObjectInfo(r.Context(), p)
@@ -118,7 +112,7 @@ func (h *handler) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeHeaders(w.Header(), r.Header, info, len(comprehensiveInfo.TagSet), bktSettings.Unversioned())
+	writeHeaders(w.Header(), r.Header, info, len(comprehensiveInfo.TagSet), bktInfo.Settings.Unversioned())
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/api/handler/locking.go
+++ b/api/handler/locking.go
@@ -57,14 +57,8 @@ func (h *handler) PutBucketObjectLockConfigHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "couldn't get bucket settings", reqInfo, err)
-		return
-	}
-
 	// settings pointer is stored in the cache, so modify a copy of the settings
-	newSettings := *settings
+	newSettings := *bktInfo.Settings
 	newSettings.LockConfiguration = lockingConf
 
 	sp := &layer.PutSettingsParams{
@@ -93,20 +87,15 @@ func (h *handler) GetBucketObjectLockConfigHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "couldn't get bucket settings", reqInfo, err)
-		return
+	lockConf := bktInfo.Settings.LockConfiguration
+	if lockConf == nil {
+		lockConf = &data.ObjectLockConfiguration{}
+	}
+	if lockConf.ObjectLockEnabled == "" {
+		lockConf.ObjectLockEnabled = enabledValue
 	}
 
-	if settings.LockConfiguration == nil {
-		settings.LockConfiguration = &data.ObjectLockConfiguration{}
-	}
-	if settings.LockConfiguration.ObjectLockEnabled == "" {
-		settings.LockConfiguration.ObjectLockEnabled = enabledValue
-	}
-
-	if err = api.EncodeToResponse(w, settings.LockConfiguration); err != nil {
+	if err = api.EncodeToResponse(w, lockConf); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}
 }
@@ -245,13 +234,7 @@ func (h *handler) PutObjectRetentionHandler(w http.ResponseWriter, r *http.Reque
 		NewLock: lock,
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	if settings.VersioningEnabled() && p.ObjVersion.VersionID == "" {
+	if bktInfo.Settings.VersioningEnabled() && p.ObjVersion.VersionID == "" {
 		shortInfoParams := &layer.ShortInfoParams{
 			Owner:  bktInfo.Owner,
 			CID:    bktInfo.CID,
@@ -288,19 +271,13 @@ func (h *handler) GetObjectRetentionHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	p := &layer.ObjectVersion{
 		BktInfo:    bktInfo,
 		ObjectName: reqInfo.ObjectName,
 		VersionID:  reqInfo.URL.Query().Get(api.QueryVersionID),
 	}
 
-	if settings.VersioningEnabled() && p.VersionID == "" {
+	if bktInfo.Settings.VersioningEnabled() && p.VersionID == "" {
 		shortInfoParams := &layer.ShortInfoParams{
 			Owner:  bktInfo.Owner,
 			CID:    bktInfo.CID,

--- a/api/handler/locking_test.go
+++ b/api/handler/locking_test.go
@@ -343,10 +343,8 @@ func TestPutBucketLockConfigurationHandler(t *testing.T) {
 
 			bktInfo, err := hc.Layer().GetBucketInfo(ctx, tc.bucket)
 			require.NoError(t, err)
-			bktSettings, err := hc.Layer().GetBucketSettings(ctx, bktInfo)
-			require.NoError(t, err)
-			actualConf := bktSettings.LockConfiguration
-			require.True(t, bktSettings.VersioningEnabled())
+			actualConf := bktInfo.Settings.LockConfiguration
+			require.True(t, bktInfo.Settings.VersioningEnabled())
 			require.Equal(t, tc.configuration.ObjectLockEnabled, actualConf.ObjectLockEnabled)
 			require.Equal(t, tc.configuration.Rule, actualConf.Rule)
 		})

--- a/api/handler/multipart_upload.go
+++ b/api/handler/multipart_upload.go
@@ -112,14 +112,8 @@ func (h *handler) CreateMultipartUploadHandler(w http.ResponseWriter, r *http.Re
 		Data: &layer.UploadData{},
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	if containsACLHeaders(r) {
-		if settings.BucketOwner == data.BucketOwnerEnforced {
+		if bktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 			if !isValidOwnerEnforced(r) {
 				h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 				return
@@ -139,7 +133,7 @@ func (h *handler) CreateMultipartUploadHandler(w http.ResponseWriter, r *http.Re
 		p.Data.ACLHeaders = formACLHeadersForMultipart(r.Header)
 	}
 
-	if settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
 		if !isValidOwnerPreferred(r) {
 			h.logAndSendError(w, "header x-amz-acl:bucket-owner-full-control must be set", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied))
 			return
@@ -484,18 +478,13 @@ func (h *handler) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		h.log.Error("couldn't send notification: %w", zap.Error(err))
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-	}
-
 	response := CompleteMultipartUploadResponse{
 		Bucket: objInfo.Bucket,
 		ETag:   objInfo.HashSum,
 		Key:    objInfo.Name,
 	}
 
-	if bktSettings.VersioningEnabled() {
+	if bktInfo.Settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, objInfo.VersionID())
 	}
 

--- a/api/handler/ownership.go
+++ b/api/handler/ownership.go
@@ -59,19 +59,15 @@ func (h *handler) PutBucketOwnershipControlsHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	bktSettings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
+	newSettings := *bktInfo.Settings
 
 	switch params.Rules[0].ObjectOwnership {
 	case amzBucketOwnerEnforced:
-		bktSettings.BucketOwner = data.BucketOwnerEnforced
+		newSettings.BucketOwner = data.BucketOwnerEnforced
 	case amzBucketOwnerPreferred:
-		bktSettings.BucketOwner = data.BucketOwnerPreferred
+		newSettings.BucketOwner = data.BucketOwnerPreferred
 	case amzBucketOwnerObjectWriter:
-		bktSettings.BucketOwner = data.BucketOwnerObjectWriter
+		newSettings.BucketOwner = data.BucketOwnerObjectWriter
 	default:
 		h.logAndSendError(w, "invalid ownership", reqInfo, s3errors.GetAPIError(s3errors.ErrBadRequest))
 		return
@@ -85,7 +81,7 @@ func (h *handler) PutBucketOwnershipControlsHandler(w http.ResponseWriter, r *ht
 
 	sp := &layer.PutSettingsParams{
 		BktInfo:  bktInfo,
-		Settings: bktSettings,
+		Settings: &newSettings,
 	}
 
 	if err = h.obj.PutBucketSettings(r.Context(), sp); err != nil {
@@ -114,13 +110,7 @@ func (h *handler) GetBucketOwnershipControlsHandler(w http.ResponseWriter, r *ht
 		}
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	switch settings.BucketOwner {
+	switch bktInfo.Settings.BucketOwner {
 	case data.BucketOwnerEnforced:
 		response = &putBucketOwnershipControlsParams{
 			Rules: []objectOwnershipRules{{ObjectOwnership: amzBucketOwnerEnforced}},
@@ -160,17 +150,12 @@ func (h *handler) DeleteBucketOwnershipControlsHandler(w http.ResponseWriter, r 
 		}
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
-	settings.BucketOwner = data.BucketOwnerEnforced
+	newSettings := *bktInfo.Settings
+	newSettings.BucketOwner = data.BucketOwnerEnforced
 
 	p := layer.PutSettingsParams{
 		BktInfo:  bktInfo,
-		Settings: settings,
+		Settings: &newSettings,
 	}
 
 	if err = h.obj.PutBucketSettings(r.Context(), &p); err != nil {

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -210,14 +210,8 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	if containsACL {
-		if settings.BucketOwner == data.BucketOwnerEnforced {
+		if bktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 			if !isValidOwnerEnforced(r) {
 				h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 				return
@@ -226,7 +220,7 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
 		if !isValidOwnerPreferred(r) {
 			h.logAndSendError(w, "header x-amz-acl:bucket-owner-full-control must be set", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied))
 			return
@@ -267,7 +261,7 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		Tags:       tagSet,
 	}
 
-	params.Lock, err = formObjectLock(r.Context(), bktInfo, settings.LockConfiguration, r.Header)
+	params.Lock, err = formObjectLock(r.Context(), bktInfo, bktInfo.Settings.LockConfiguration, r.Header)
 	if err != nil {
 		h.logAndSendError(w, "could not form object lock", reqInfo, err)
 		return
@@ -325,7 +319,7 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if settings.VersioningEnabled() {
+	if bktInfo.Settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, objInfo.VersionID())
 	}
 	if encryptionParams.Enabled() {
@@ -438,14 +432,8 @@ func (h *handler) PostObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	if containsACL {
-		if settings.BucketOwner == data.BucketOwnerEnforced {
+		if bktInfo.Settings.BucketOwner == data.BucketOwnerEnforced {
 			if !isValidOwnerEnforced(r) {
 				h.logAndSendError(w, "access control list not supported", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessControlListNotSupported))
 				return
@@ -454,7 +442,7 @@ func (h *handler) PostObject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
+	if bktInfo.Settings.BucketOwner == data.BucketOwnerPreferredAndRestricted {
 		if !isValidOwnerPreferred(r) {
 			h.logAndSendError(w, "header x-amz-acl:bucket-owner-full-control must be set", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied))
 			return
@@ -518,9 +506,7 @@ func (h *handler) PostObject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo); err != nil {
-		h.log.Warn("couldn't get bucket versioning", zap.String("bucket name", reqInfo.BucketName), zap.Error(err))
-	} else if settings.VersioningEnabled() {
+	if bktInfo.Settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, objInfo.VersionID())
 	}
 

--- a/api/handler/put.go
+++ b/api/handler/put.go
@@ -275,12 +275,19 @@ func (h *handler) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 
 	extendedObjInfo, err := h.obj.PutObject(r.Context(), params)
 	if err != nil {
-		_, err2 := io.Copy(io.Discard, r.Body)
-		err3 := r.Body.Close()
 		if errors.Is(err, apistatus.ErrObjectAccessDenied) {
 			h.logAndSendError(w, "could not upload object", reqInfo, s3errors.GetAPIError(s3errors.ErrAccessDenied), zap.Error(err))
 			return
 		}
+
+		var s3err s3errors.Error
+		if errors.As(err, &s3err) {
+			h.logAndSendError(w, "could not upload object", reqInfo, s3err, zap.Error(err))
+			return
+		}
+
+		_, err2 := io.Copy(io.Discard, r.Body)
+		err3 := r.Body.Close()
 
 		h.logAndSendError(w, "could not upload object", reqInfo, err, zap.Errors("body close errors", []error{err2, err3}))
 		return

--- a/api/handler/tagging.go
+++ b/api/handler/tagging.go
@@ -97,12 +97,6 @@ func (h *handler) GetObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "could not get bucket settings", reqInfo, err)
-		return
-	}
-
 	tagPrm := &layer.GetObjectTaggingParams{
 		ObjectVersion: &layer.ObjectVersion{
 			BktInfo:    bktInfo,
@@ -134,7 +128,7 @@ func (h *handler) GetObjectTaggingHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if settings.VersioningEnabled() {
+	if bktInfo.Settings.VersioningEnabled() {
 		w.Header().Set(api.AmzVersionID, versionID)
 	}
 	if err = api.EncodeToResponse(w, encodeTagging(tagSet)); err != nil {

--- a/api/handler/versioning.go
+++ b/api/handler/versioning.go
@@ -25,19 +25,13 @@ func (h *handler) PutBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "couldn't get bucket settings", reqInfo, err)
-		return
-	}
-
 	if configuration.Status != data.VersioningEnabled && configuration.Status != data.VersioningSuspended {
 		h.logAndSendError(w, "invalid versioning configuration", reqInfo, s3errors.GetAPIError(s3errors.ErrMalformedXML))
 		return
 	}
 
 	// settings pointer is stored in the cache, so modify a copy of the settings
-	newSettings := *settings
+	newSettings := *bktInfo.Settings
 	newSettings.Versioning = configuration.Status
 
 	p := &layer.PutSettingsParams{
@@ -67,13 +61,7 @@ func (h *handler) GetBucketVersioningHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	settings, err := h.obj.GetBucketSettings(r.Context(), bktInfo)
-	if err != nil {
-		h.logAndSendError(w, "couldn't get version settings", reqInfo, err)
-		return
-	}
-
-	if err = api.EncodeToResponse(w, formVersioningConfiguration(settings)); err != nil {
+	if err = api.EncodeToResponse(w, formVersioningConfiguration(bktInfo.Settings)); err != nil {
 		h.logAndSendError(w, "something went wrong", reqInfo, err)
 	}
 }

--- a/api/layer/cache.go
+++ b/api/layer/cache.go
@@ -10,6 +10,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	settingsCacheKeySuffix      = ".settings"
+	corsCacheKeySuffix          = ".cors"
+	notificationsCacheKeySuffix = ".notifications"
+)
+
 type Cache struct {
 	logger         *zap.Logger
 	listsCache     *cache.ObjectsListCache
@@ -188,20 +194,20 @@ func (c *Cache) PutLockInfo(owner user.ID, key string, lockInfo *data.LockInfo) 
 }
 
 func (c *Cache) GetSettings(bktInfo *data.BucketInfo) *data.BucketSettings {
-	key := bktInfo.Name + bktInfo.SettingsObjectName()
+	key := bktInfo.Name + settingsCacheKeySuffix
 
 	return c.systemCache.GetSettings(key)
 }
 
 func (c *Cache) PutSettings(bktInfo *data.BucketInfo, settings *data.BucketSettings) {
-	key := bktInfo.Name + bktInfo.SettingsObjectName()
+	key := bktInfo.Name + settingsCacheKeySuffix
 	if err := c.systemCache.PutSettings(key, settings); err != nil {
 		c.logger.Warn("couldn't cache bucket settings", zap.String("bucket", bktInfo.Name), zap.Error(err))
 	}
 }
 
 func (c *Cache) GetCORS(owner user.ID, bkt *data.BucketInfo) *data.CORSConfiguration {
-	key := bkt.Name + bkt.CORSObjectName()
+	key := bkt.Name + corsCacheKeySuffix
 
 	if !c.accessCache.Get(owner, key) {
 		return nil
@@ -211,7 +217,7 @@ func (c *Cache) GetCORS(owner user.ID, bkt *data.BucketInfo) *data.CORSConfigura
 }
 
 func (c *Cache) PutCORS(owner user.ID, bkt *data.BucketInfo, cors *data.CORSConfiguration) {
-	key := bkt.Name + bkt.CORSObjectName()
+	key := bkt.Name + corsCacheKeySuffix
 
 	if err := c.systemCache.PutCORS(key, cors); err != nil {
 		c.logger.Warn("couldn't cache cors", zap.String("bucket", bkt.Name), zap.Error(err))
@@ -223,11 +229,11 @@ func (c *Cache) PutCORS(owner user.ID, bkt *data.BucketInfo, cors *data.CORSConf
 }
 
 func (c *Cache) DeleteCORS(bktInfo *data.BucketInfo) {
-	c.systemCache.Delete(bktInfo.Name + bktInfo.CORSObjectName())
+	c.systemCache.Delete(bktInfo.Name + corsCacheKeySuffix)
 }
 
 func (c *Cache) GetNotificationConfiguration(owner user.ID, bktInfo *data.BucketInfo) *data.NotificationConfiguration {
-	key := bktInfo.Name + bktInfo.NotificationConfigurationObjectName()
+	key := bktInfo.Name + notificationsCacheKeySuffix
 
 	if !c.accessCache.Get(owner, key) {
 		return nil
@@ -237,7 +243,7 @@ func (c *Cache) GetNotificationConfiguration(owner user.ID, bktInfo *data.Bucket
 }
 
 func (c *Cache) PutNotificationConfiguration(owner user.ID, bktInfo *data.BucketInfo, configuration *data.NotificationConfiguration) {
-	key := bktInfo.Name + bktInfo.NotificationConfigurationObjectName()
+	key := bktInfo.Name + notificationsCacheKeySuffix
 	if err := c.systemCache.PutNotificationConfiguration(key, configuration); err != nil {
 		c.logger.Warn("couldn't cache notification configuration", zap.String("bucket", bktInfo.Name), zap.Error(err))
 	}

--- a/api/layer/cache.go
+++ b/api/layer/cache.go
@@ -10,12 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	settingsCacheKeySuffix      = ".settings"
-	corsCacheKeySuffix          = ".cors"
-	notificationsCacheKeySuffix = ".notifications"
-)
-
 type Cache struct {
 	logger         *zap.Logger
 	listsCache     *cache.ObjectsListCache
@@ -186,66 +180,6 @@ func (c *Cache) GetLockInfo(owner user.ID, key string) *data.LockInfo {
 func (c *Cache) PutLockInfo(owner user.ID, key string, lockInfo *data.LockInfo) {
 	if err := c.systemCache.PutLockInfo(key, lockInfo); err != nil {
 		c.logger.Error("couldn't cache lock info", zap.Error(err))
-	}
-
-	if err := c.accessCache.Put(owner, key); err != nil {
-		c.logger.Warn("couldn't cache access control operation", zap.Error(err))
-	}
-}
-
-func (c *Cache) GetSettings(bktInfo *data.BucketInfo) *data.BucketSettings {
-	key := bktInfo.Name + settingsCacheKeySuffix
-
-	return c.systemCache.GetSettings(key)
-}
-
-func (c *Cache) PutSettings(bktInfo *data.BucketInfo, settings *data.BucketSettings) {
-	key := bktInfo.Name + settingsCacheKeySuffix
-	if err := c.systemCache.PutSettings(key, settings); err != nil {
-		c.logger.Warn("couldn't cache bucket settings", zap.String("bucket", bktInfo.Name), zap.Error(err))
-	}
-}
-
-func (c *Cache) GetCORS(owner user.ID, bkt *data.BucketInfo) *data.CORSConfiguration {
-	key := bkt.Name + corsCacheKeySuffix
-
-	if !c.accessCache.Get(owner, key) {
-		return nil
-	}
-
-	return c.systemCache.GetCORS(key)
-}
-
-func (c *Cache) PutCORS(owner user.ID, bkt *data.BucketInfo, cors *data.CORSConfiguration) {
-	key := bkt.Name + corsCacheKeySuffix
-
-	if err := c.systemCache.PutCORS(key, cors); err != nil {
-		c.logger.Warn("couldn't cache cors", zap.String("bucket", bkt.Name), zap.Error(err))
-	}
-
-	if err := c.accessCache.Put(owner, key); err != nil {
-		c.logger.Warn("couldn't cache access control operation", zap.Error(err))
-	}
-}
-
-func (c *Cache) DeleteCORS(bktInfo *data.BucketInfo) {
-	c.systemCache.Delete(bktInfo.Name + corsCacheKeySuffix)
-}
-
-func (c *Cache) GetNotificationConfiguration(owner user.ID, bktInfo *data.BucketInfo) *data.NotificationConfiguration {
-	key := bktInfo.Name + notificationsCacheKeySuffix
-
-	if !c.accessCache.Get(owner, key) {
-		return nil
-	}
-
-	return c.systemCache.GetNotificationConfiguration(key)
-}
-
-func (c *Cache) PutNotificationConfiguration(owner user.ID, bktInfo *data.BucketInfo, configuration *data.NotificationConfiguration) {
-	key := bktInfo.Name + notificationsCacheKeySuffix
-	if err := c.systemCache.PutNotificationConfiguration(key, configuration); err != nil {
-		c.logger.Warn("couldn't cache notification configuration", zap.String("bucket", bktInfo.Name), zap.Error(err))
 	}
 
 	if err := c.accessCache.Put(owner, key); err != nil {

--- a/api/layer/container.go
+++ b/api/layer/container.go
@@ -65,6 +65,11 @@ func (n *layer) containerInfo(ctx context.Context, idCnr cid.ID) (*data.BucketIn
 	info.AttributeSettings = cnr.Attribute(attributeSettings)
 	info.AttributeNotifications = cnr.Attribute(attributeNotifications)
 
+	if err = info.ParseSettings(); err != nil {
+		log.Error("could not parse bucket settings from container attributes", zap.Error(err), zap.Stringer("cid", idCnr))
+		return nil, err
+	}
+
 	attrLockEnabled := cnr.Attribute(AttributeLockEnabled)
 	if len(attrLockEnabled) > 0 {
 		info.ObjectLockEnabled, err = strconv.ParseBool(attrLockEnabled)
@@ -124,6 +129,8 @@ func (n *layer) createContainer(ctx context.Context, p *CreateBucketParams) (*da
 		Created:            TimeNow(ctx),
 		LocationConstraint: p.LocationConstraint,
 		ObjectLockEnabled:  p.ObjectLockEnabled,
+		Settings:           &data.BucketSettings{Versioning: data.VersioningUnversioned},
+		Notifications:      &data.NotificationConfiguration{},
 	}
 
 	var attributes [][2]string

--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -5,18 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"slices"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
 	"github.com/nspcc-dev/neofs-s3-gw/api/s3errors"
-	"github.com/nspcc-dev/neofs-s3-gw/api/s3headers"
-	"github.com/nspcc-dev/neofs-sdk-go/client"
-	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/nspcc-dev/neofs-sdk-go/session/v2"
 )
 
@@ -80,71 +75,27 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 }
 
 func (n *layer) GetBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (*data.CORSConfiguration, error) {
-	var (
-		err   error
-		owner = n.Owner(ctx)
-	)
+	var owner = n.Owner(ctx)
 
 	if cors := n.cache.GetCORS(owner, bktInfo); cors != nil {
 		return cors, nil
 	}
 
-	var corsRules []data.CORSRule
-	if bktInfo.AttributeCors != "" {
-		if err = json.Unmarshal([]byte(bktInfo.AttributeCors), &corsRules); err != nil {
-			return nil, fmt.Errorf("malformed data: %w", err)
-		}
-
-		cors := &data.CORSConfiguration{
-			CORSRules: corsRules,
-		}
-
-		n.cache.PutCORS(owner, bktInfo, cors)
-		return cors, nil
-	}
-
-	id, err := n.searchBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketCORS)
-	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
-	}
-
-	if id.IsZero() {
+	if bktInfo.AttributeCors == "" {
 		return nil, s3errors.GetAPIError(s3errors.ErrNoSuchCORSConfiguration)
 	}
 
-	obj, err := n.objectGet(ctx, bktInfo, id)
-	if err != nil {
-		return nil, err
+	var corsRules []data.CORSRule
+	if err := json.Unmarshal([]byte(bktInfo.AttributeCors), &corsRules); err != nil {
+		return nil, fmt.Errorf("malformed data: %w", err)
 	}
 
-	cors := &data.CORSConfiguration{}
-
-	if err = xml.Unmarshal(obj.Payload(), &cors); err != nil {
-		return nil, fmt.Errorf("unmarshal cors: %w", err)
-	}
-
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		// Migrate CORS to contract.
-		if err = n.storeAttribute(ctx, bktInfo.CID, attributeCors, cors.CORSRules, boxData.Gate.SessionTokenV2); err != nil {
-			return nil, fmt.Errorf("migrate bucket CORS: %w", err)
-		}
-		if err = n.deleteBucketCORS(ctx, bktInfo); err != nil {
-			return nil, fmt.Errorf("delete bucket CORS: %w", err)
-		}
-	}
-
+	cors := &data.CORSConfiguration{CORSRules: corsRules}
 	n.cache.PutCORS(owner, bktInfo, cors)
-	n.cache.DeleteBucket(bktInfo.Name)
-
 	return cors, nil
 }
 
 func (n *layer) DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) error {
-	if err := n.deleteBucketCORS(ctx, bktInfo); err != nil {
-		return fmt.Errorf("delete bucket CORS: %w", err)
-	}
-
 	var sessionTokenV2 *session.Token
 	boxData, err := GetBoxData(ctx)
 	if err == nil {
@@ -157,38 +108,6 @@ func (n *layer) DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) 
 
 	n.cache.DeleteCORS(bktInfo)
 	n.cache.DeleteBucket(bktInfo.Name)
-
-	return nil
-}
-
-func (n *layer) deleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) error {
-	fs := make(object.SearchFilters, 0, 2)
-	fs.AddFilter(s3headers.MetaType, s3headers.TypeBucketCORS, object.MatchStringEqual)
-	fs.AddTypeFilter(object.MatchStringEqual, object.TypeRegular)
-
-	var opts client.SearchObjectsOptions
-	attachTokenToParams(ctx, bktInfo.Owner, &opts)
-
-	res, err := n.neoFS.SearchObjectsV2(ctx, bktInfo.CID, fs, nil, opts)
-	if err != nil {
-		if errors.Is(err, apistatus.ErrObjectAccessDenied) {
-			return s3errors.GetAPIError(s3errors.ErrAccessDenied)
-		}
-
-		return fmt.Errorf("search object version: %w", err)
-	}
-
-	if len(res) == 0 {
-		return nil
-	}
-
-	for i := range res {
-		if err = n.objectDelete(ctx, bktInfo, res[i].ID); err != nil {
-			return fmt.Errorf("couldn't delete bucket CORS object: %w", err)
-		}
-	}
-
-	n.cache.DeleteCORS(bktInfo)
 
 	return nil
 }

--- a/api/layer/cors.go
+++ b/api/layer/cors.go
@@ -68,31 +68,17 @@ func (n *layer) PutBucketCORS(ctx context.Context, p *PutCORSParams) error {
 		return fmt.Errorf("store bucket CORS: %w", err)
 	}
 
-	n.cache.PutCORS(n.Owner(ctx), p.BktInfo, cors)
 	n.cache.DeleteBucket(p.BktInfo.Name)
 
 	return nil
 }
 
-func (n *layer) GetBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) (*data.CORSConfiguration, error) {
-	var owner = n.Owner(ctx)
-
-	if cors := n.cache.GetCORS(owner, bktInfo); cors != nil {
-		return cors, nil
-	}
-
-	if bktInfo.AttributeCors == "" {
+func (n *layer) GetBucketCORS(_ context.Context, bktInfo *data.BucketInfo) (*data.CORSConfiguration, error) {
+	if bktInfo.CORS == nil {
 		return nil, s3errors.GetAPIError(s3errors.ErrNoSuchCORSConfiguration)
 	}
 
-	var corsRules []data.CORSRule
-	if err := json.Unmarshal([]byte(bktInfo.AttributeCors), &corsRules); err != nil {
-		return nil, fmt.Errorf("malformed data: %w", err)
-	}
-
-	cors := &data.CORSConfiguration{CORSRules: corsRules}
-	n.cache.PutCORS(owner, bktInfo, cors)
-	return cors, nil
+	return bktInfo.CORS, nil
 }
 
 func (n *layer) DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) error {
@@ -106,7 +92,6 @@ func (n *layer) DeleteBucketCORS(ctx context.Context, bktInfo *data.BucketInfo) 
 		return fmt.Errorf("remove bucket CORS: %w", err)
 	}
 
-	n.cache.DeleteCORS(bktInfo)
 	n.cache.DeleteBucket(bktInfo.Name)
 
 	return nil

--- a/api/layer/layer.go
+++ b/api/layer/layer.go
@@ -217,7 +217,6 @@ type (
 	Client interface {
 		Initialize(ctx context.Context, c EventListener) error
 
-		GetBucketSettings(ctx context.Context, bktInfo *data.BucketInfo) (*data.BucketSettings, error)
 		PutBucketSettings(ctx context.Context, p *PutSettingsParams) error
 
 		PutBucketCORS(ctx context.Context, p *PutCORSParams) error
@@ -585,9 +584,8 @@ func (n *layer) GetObjectInfo(ctx context.Context, p *HeadObjectParams) (*data.O
 // GetExtendedObjectInfo returns meta information and corresponding info about the object.
 func (n *layer) GetExtendedObjectInfo(ctx context.Context, p *HeadObjectParams) (*data.ExtendedObjectInfo, error) {
 	var (
-		id       oid.ID
-		err      error
-		settings *data.BucketSettings
+		id  oid.ID
+		err error
 	)
 
 	versions, err := n.searchAllVersionsInNeoFS(ctx, p.BktInfo, p.Object, p.VersionID == data.UnversionedObjectVersionID)
@@ -612,14 +610,9 @@ func (n *layer) GetExtendedObjectInfo(ctx context.Context, p *HeadObjectParams) 
 
 		id = versions[0].ID
 	} else {
-		settings, err = n.GetBucketSettings(ctx, p.BktInfo)
-		if err != nil {
-			return nil, fmt.Errorf("get bucket settings: %w", err)
-		}
-
 		var foundVersion *allVersionsSearchResult
 
-		if settings.VersioningEnabled() {
+		if p.BktInfo.Settings.VersioningEnabled() {
 			for _, version := range versions {
 				if version.ID.EncodeToString() == p.VersionID {
 					foundVersion = &version

--- a/api/layer/locking_test.go
+++ b/api/layer/locking_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestObjectLockAttributes(t *testing.T) {
 	tc := prepareContext(t)
-	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
-		BktInfo:  tc.bktInfo,
-		Settings: &data.BucketSettings{Versioning: data.VersioningEnabled},
-	})
-	require.NoError(t, err)
+	tc.putBucketSettings(&data.BucketSettings{Versioning: data.VersioningEnabled})
 
 	obj := tc.putObject([]byte("content obj1 v1"))
 
@@ -32,7 +28,7 @@ func TestObjectLockAttributes(t *testing.T) {
 		},
 	}
 
-	err = tc.layer.PutLockInfo(tc.ctx, p)
+	err := tc.layer.PutLockInfo(tc.ctx, p)
 	require.NoError(t, err)
 
 	foundLock, err := tc.layer.GetLockInfo(tc.ctx, p.ObjVersion)

--- a/api/layer/multipart_upload.go
+++ b/api/layer/multipart_upload.go
@@ -1344,18 +1344,13 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 		Encryption: p.Info.Encryption,
 	}
 
-	bktSettings, err := n.GetBucketSettings(ctx, p.Info.Bkt)
-	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't get versioning settings object: %w", err)
-	}
-
 	var (
 		oldVersions    []allVersionsSearchResult
 		oldVersionsErr error
 		wg             sync.WaitGroup
 	)
 
-	if !bktSettings.VersioningEnabled() {
+	if !p.Info.Bkt.Settings.VersioningEnabled() {
 		wg.Go(func() {
 			oldVersions, oldVersionsErr = n.searchAllVersionsInNeoFS(ctx, p.Info.Bkt, p.Info.Key, true)
 		})
@@ -1365,7 +1360,7 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 		PutObject:         prmHeaderObject,
 		PayloadHash:       multipartHash,
 		PayloadLength:     uint64(multipartObjetSize),
-		VersioningEnabled: bktSettings.VersioningEnabled(),
+		VersioningEnabled: p.Info.Bkt.Settings.VersioningEnabled(),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -1467,7 +1462,7 @@ func (n *layer) CompleteMultipartUpload(ctx context.Context, p *CompleteMultipar
 		FilePath:      p.Info.Key,
 		OID:           headerObjectID,
 		ETag:          hex.EncodeToString(multipartHash.Sum(nil)),
-		IsUnversioned: !bktSettings.VersioningEnabled(),
+		IsUnversioned: !p.Info.Bkt.Settings.VersioningEnabled(),
 	}
 
 	n.cache.CleanListCacheEntriesContainingObject(p.Info.Key, p.Info.Bkt.CID)

--- a/api/layer/neofs_mock.go
+++ b/api/layer/neofs_mock.go
@@ -634,11 +634,36 @@ func (t *TestNeoFS) SearchObjectsV2WithCursor(_ context.Context, cid cid.ID, fil
 	return result, nextCursor, nil
 }
 
-func (t *TestNeoFS) SetContainerAttribute(_ context.Context, _ cid.ID, _, _ string, _ *session.Token) error {
+func (t *TestNeoFS) SetContainerAttribute(_ context.Context, id cid.ID, key, value string, _ *session.Token) error {
+	cnr, ok := t.containers[id.EncodeToString()]
+	if !ok {
+		return fmt.Errorf("container not found %s", id.EncodeToString())
+	}
+
+	cnr.SetAttribute(key, value)
 	return nil
 }
 
-func (t *TestNeoFS) RemoveContainerAttribute(_ context.Context, _ cid.ID, _ string, _ *session.Token) error {
+func (t *TestNeoFS) RemoveContainerAttribute(_ context.Context, id cid.ID, key string, _ *session.Token) error {
+	cnr, ok := t.containers[id.EncodeToString()]
+	if !ok {
+		return fmt.Errorf("container not found %s", id.String())
+	}
+
+	// The SDK container keeps attributes in a private slice with no removal
+	// API, so rebuild the container without the dropped attribute.
+	var rebuilt container.Container
+	rebuilt.Init()
+	rebuilt.SetOwner(cnr.Owner())
+	rebuilt.SetPlacementPolicy(cnr.PlacementPolicy())
+	rebuilt.SetBasicACL(cnr.BasicACL())
+	for k, v := range cnr.Attributes() {
+		if k != key {
+			rebuilt.SetAttribute(k, v)
+		}
+	}
+
+	t.containers[id.EncodeToString()] = &rebuilt
 	return nil
 }
 

--- a/api/layer/notifications.go
+++ b/api/layer/notifications.go
@@ -3,12 +3,10 @@ package layer
 import (
 	"context"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
 	"github.com/nspcc-dev/neofs-s3-gw/api/data"
-	"github.com/nspcc-dev/neofs-s3-gw/api/s3headers"
 	"github.com/nspcc-dev/neofs-sdk-go/session/v2"
 )
 
@@ -41,46 +39,13 @@ func (n *layer) GetBucketNotificationConfiguration(ctx context.Context, bktInfo 
 		return conf, nil
 	}
 
-	var conf = data.NotificationConfiguration{}
+	var conf = &data.NotificationConfiguration{}
 	if bktInfo.AttributeNotifications != "" {
-		if err := json.Unmarshal([]byte(bktInfo.AttributeNotifications), &conf); err != nil {
+		if err := json.Unmarshal([]byte(bktInfo.AttributeNotifications), conf); err != nil {
 			return nil, fmt.Errorf("malformed data: %w", err)
 		}
-
-		n.cache.PutNotificationConfiguration(n.Owner(ctx), bktInfo, &conf)
-		return &conf, nil
 	}
 
-	id, err := n.searchBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketNotifConfig)
-	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
-	}
-
-	if id.IsZero() {
-		return &conf, nil
-	}
-
-	obj, err := n.objectGet(ctx, bktInfo, id)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = xml.Unmarshal(obj.Payload(), &conf); err != nil {
-		return nil, fmt.Errorf("unmarshal notify configuration: %w", err)
-	}
-
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		// Migrate notification settings.
-		if err = n.storeAttribute(ctx, bktInfo.CID, attributeNotifications, conf, boxData.Gate.SessionTokenV2); err != nil {
-			return nil, fmt.Errorf("migrate bucket notification settings: %w", err)
-		}
-		if err = n.deleteBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketNotifConfig); err != nil {
-			return nil, fmt.Errorf("delete bucket notification settings: %w", err)
-		}
-	}
-
-	n.cache.PutNotificationConfiguration(owner, bktInfo, &conf)
-
-	return &conf, nil
+	n.cache.PutNotificationConfiguration(owner, bktInfo, conf)
+	return conf, nil
 }

--- a/api/layer/notifications.go
+++ b/api/layer/notifications.go
@@ -2,7 +2,6 @@ package layer
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-s3-gw/api"
@@ -27,25 +26,11 @@ func (n *layer) PutBucketNotificationConfiguration(ctx context.Context, p *PutBu
 		return fmt.Errorf("store bucket notification settings: %w", err)
 	}
 
-	n.cache.PutNotificationConfiguration(n.Owner(ctx), p.BktInfo, p.Configuration)
 	n.cache.DeleteBucket(p.BktInfo.Name)
 
 	return nil
 }
 
-func (n *layer) GetBucketNotificationConfiguration(ctx context.Context, bktInfo *data.BucketInfo) (*data.NotificationConfiguration, error) {
-	owner := n.Owner(ctx)
-	if conf := n.cache.GetNotificationConfiguration(owner, bktInfo); conf != nil {
-		return conf, nil
-	}
-
-	var conf = &data.NotificationConfiguration{}
-	if bktInfo.AttributeNotifications != "" {
-		if err := json.Unmarshal([]byte(bktInfo.AttributeNotifications), conf); err != nil {
-			return nil, fmt.Errorf("malformed data: %w", err)
-		}
-	}
-
-	n.cache.PutNotificationConfiguration(owner, bktInfo, conf)
-	return conf, nil
+func (n *layer) GetBucketNotificationConfiguration(_ context.Context, bktInfo *data.BucketInfo) (*data.NotificationConfiguration, error) {
+	return bktInfo.Notifications, nil
 }

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -103,11 +103,6 @@ type (
 		IsVersioned       bool
 	}
 
-	baseSearchResult struct {
-		ID                oid.ID
-		CreationTimestamp int64
-	}
-
 	// PartSearchResult contains some part metadata.
 	PartSearchResult struct {
 		ID                oid.ID
@@ -1400,103 +1395,6 @@ func tryDirectoryName(filePath string, prefix, delimiter string) string {
 	}
 
 	return ""
-}
-
-func (n *layer) searchBucketMetaObjects(ctx context.Context, bktInfo *data.BucketInfo, objType string) (oid.ID, error) {
-	var (
-		opts                client.SearchObjectsOptions
-		owner               = n.Owner(ctx)
-		filters             = make(object.SearchFilters, 0, 2)
-		returningAttributes = []string{
-			s3headers.MetaType,
-			object.AttributeTimestamp,
-		}
-	)
-
-	attachTokenToParams(ctx, owner, &opts)
-
-	filters.AddFilter(s3headers.MetaType, objType, object.MatchStringEqual)
-	filters.AddTypeFilter(object.MatchStringEqual, object.TypeRegular)
-
-	searchResultItems, err := n.neoFS.SearchObjectsV2(ctx, bktInfo.CID, filters, returningAttributes, opts)
-	if err != nil {
-		if errors.Is(err, apistatus.ErrObjectAccessDenied) {
-			return oid.ID{}, s3errors.GetAPIError(s3errors.ErrAccessDenied)
-		}
-
-		return oid.ID{}, fmt.Errorf("search object version: %w", err)
-	}
-
-	if len(searchResultItems) == 0 {
-		return oid.ID{}, nil
-	}
-
-	var searchResults = make([]baseSearchResult, 0, len(searchResultItems))
-
-	for _, item := range searchResultItems {
-		var psr = baseSearchResult{
-			ID: item.ID,
-		}
-
-		if item.Attributes[1] != "" {
-			psr.CreationTimestamp, err = strconv.ParseInt(item.Attributes[1], 10, 64)
-			if err != nil {
-				return oid.ID{}, fmt.Errorf("invalid creation timestamp %s: %w", item.Attributes[1], err)
-			}
-		}
-
-		searchResults = append(searchResults, psr)
-	}
-
-	sortFunc := func(a, b baseSearchResult) int {
-		if c := cmp.Compare(b.CreationTimestamp, a.CreationTimestamp); c != 0 { // reverse order.
-			return c
-		}
-
-		// It is a temporary decision. We can't figure out what object was first and what the second right now.
-		return b.ID.Compare(a.ID) // reverse order.
-	}
-
-	slices.SortFunc(searchResults, sortFunc)
-
-	return searchResults[0].ID, nil
-}
-
-func (n *layer) deleteBucketMetaObjects(ctx context.Context, bktInfo *data.BucketInfo, objType string) error {
-	var (
-		opts                client.SearchObjectsOptions
-		owner               = n.Owner(ctx)
-		filters             = make(object.SearchFilters, 0, 2)
-		returningAttributes = []string{
-			s3headers.MetaType,
-		}
-	)
-
-	attachTokenToParams(ctx, owner, &opts)
-
-	filters.AddFilter(s3headers.MetaType, objType, object.MatchStringEqual)
-	filters.AddTypeFilter(object.MatchStringEqual, object.TypeRegular)
-
-	searchResultItems, err := n.neoFS.SearchObjectsV2(ctx, bktInfo.CID, filters, returningAttributes, opts)
-	if err != nil {
-		if errors.Is(err, apistatus.ErrObjectAccessDenied) {
-			return s3errors.GetAPIError(s3errors.ErrAccessDenied)
-		}
-
-		return fmt.Errorf("search object version: %w", err)
-	}
-
-	if len(searchResultItems) == 0 {
-		return nil
-	}
-
-	for _, item := range searchResultItems {
-		if err = n.objectDelete(ctx, bktInfo, item.ID); err != nil {
-			return fmt.Errorf("remove %s metaobject for %s: %w", objType, bktInfo.CID.EncodeToString(), err)
-		}
-	}
-
-	return nil
 }
 
 func extractLockDataFromAttrubute(lsr *locksSearchResult, attributeValue string) error {

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -218,14 +218,11 @@ func encryptionReader(r io.Reader, size uint64, key []byte) (io.Reader, uint64, 
 func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.ExtendedObjectInfo, error) {
 	owner := n.Owner(ctx)
 
-	bktSettings, err := n.GetBucketSettings(ctx, p.BktInfo)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't get versioning settings object: %w", err)
-	}
+	var err error
 
 	newVersion := &data.NodeVersion{
 		FilePath:      p.Object,
-		IsUnversioned: !bktSettings.VersioningEnabled(),
+		IsUnversioned: !p.BktInfo.Settings.VersioningEnabled(),
 	}
 
 	r := p.Reader
@@ -287,7 +284,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		Attributes:   p.Header,
 	}
 
-	if bktSettings.VersioningEnabled() {
+	if p.BktInfo.Settings.VersioningEnabled() {
 		prm.Attributes[s3headers.AttributeVersioningState] = data.VersioningEnabled
 		oldVersions = nil
 	}
@@ -340,7 +337,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 			NewLock: p.Lock,
 		}
 
-		if bktSettings.VersioningEnabled() {
+		if p.BktInfo.Settings.VersioningEnabled() {
 			putLockInfoPrms.ObjVersion.VersionID = id.String()
 		}
 

--- a/api/layer/object.go
+++ b/api/layer/object.go
@@ -242,6 +242,17 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		p.Size = int64(encSize)
 	}
 
+	oldVersions, oldVersionsErr := n.searchAllVersionsInNeoFS(ctx, p.BktInfo, p.Object, true)
+	if oldVersionsErr != nil && !errors.Is(oldVersionsErr, ErrNodeNotFound) {
+		n.log.Warn("search old object versions failed",
+			zap.String("object", p.Object),
+			zap.String("bucket", p.BktInfo.Name),
+			zap.Stringer("cid", p.BktInfo.CID),
+			zap.Error(oldVersionsErr))
+
+		return nil, fmt.Errorf("search all versions in neofs: %w", oldVersionsErr)
+	}
+
 	if r != nil {
 		if len(p.Header[api.ContentType]) == 0 {
 			if contentType := MimeByFilePath(p.Object); len(contentType) == 0 {
@@ -276,18 +287,9 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		Attributes:   p.Header,
 	}
 
-	var (
-		oldVersions    []allVersionsSearchResult
-		oldVersionsErr error
-		wg             sync.WaitGroup
-	)
-
 	if bktSettings.VersioningEnabled() {
 		prm.Attributes[s3headers.AttributeVersioningState] = data.VersioningEnabled
-	} else {
-		wg.Go(func() {
-			oldVersions, oldVersionsErr = n.searchAllVersionsInNeoFS(ctx, p.BktInfo, p.Object, true)
-		})
+		oldVersions = nil
 	}
 
 	id, hash, err := n.objectPutAndHash(ctx, prm, p.BktInfo)
@@ -295,16 +297,7 @@ func (n *layer) PutObject(ctx context.Context, p *PutObjectParams) (*data.Extend
 		return nil, err
 	}
 
-	// We need new object id to filter it out.
-	wg.Wait()
-
-	if oldVersionsErr != nil && !errors.Is(oldVersionsErr, ErrNodeNotFound) {
-		n.log.Warn("search old object versions failed",
-			zap.String("object", p.Object),
-			zap.String("bucket", p.BktInfo.Name),
-			zap.Stringer("cid", p.BktInfo.CID),
-			zap.Error(oldVersionsErr))
-	}
+	var wg sync.WaitGroup
 
 	if len(oldVersions) > 0 {
 		wg.Go(func() {

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -233,19 +233,7 @@ func lockObjectKey(objVersion *ObjectVersion) string {
 }
 
 func (n *layer) GetBucketSettings(_ context.Context, bktInfo *data.BucketInfo) (*data.BucketSettings, error) {
-	if settings := n.cache.GetSettings(bktInfo); settings != nil {
-		return settings, nil
-	}
-
-	var settings = &data.BucketSettings{Versioning: data.VersioningUnversioned}
-	if bktInfo.AttributeSettings != "" {
-		if err := json.Unmarshal([]byte(bktInfo.AttributeSettings), settings); err != nil {
-			return nil, fmt.Errorf("malformed data: %w", err)
-		}
-	}
-
-	n.cache.PutSettings(bktInfo, settings)
-	return settings, nil
+	return bktInfo.Settings, nil
 }
 
 // PutBucketSettings stores bucket settings. We should save the latest file version only.
@@ -260,7 +248,6 @@ func (n *layer) PutBucketSettings(ctx context.Context, p *PutSettingsParams) err
 		return fmt.Errorf("store bucket settings: %w", err)
 	}
 
-	n.cache.PutSettings(p.BktInfo, p.Settings)
 	n.cache.DeleteBucket(p.BktInfo.Name)
 
 	return nil

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -232,10 +232,6 @@ func lockObjectKey(objVersion *ObjectVersion) string {
 	return ".lock." + objVersion.BktInfo.CID.EncodeToString() + "." + objVersion.ObjectName + "." + objVersion.VersionID
 }
 
-func (n *layer) GetBucketSettings(_ context.Context, bktInfo *data.BucketInfo) (*data.BucketSettings, error) {
-	return bktInfo.Settings, nil
-}
-
 // PutBucketSettings stores bucket settings. We should save the latest file version only.
 func (n *layer) PutBucketSettings(ctx context.Context, p *PutSettingsParams) error {
 	var sessionTokenV2 *session.Token

--- a/api/layer/system_object.go
+++ b/api/layer/system_object.go
@@ -232,7 +232,7 @@ func lockObjectKey(objVersion *ObjectVersion) string {
 	return ".lock." + objVersion.BktInfo.CID.EncodeToString() + "." + objVersion.ObjectName + "." + objVersion.VersionID
 }
 
-func (n *layer) GetBucketSettings(ctx context.Context, bktInfo *data.BucketInfo) (*data.BucketSettings, error) {
+func (n *layer) GetBucketSettings(_ context.Context, bktInfo *data.BucketInfo) (*data.BucketSettings, error) {
 	if settings := n.cache.GetSettings(bktInfo); settings != nil {
 		return settings, nil
 	}
@@ -242,89 +242,10 @@ func (n *layer) GetBucketSettings(ctx context.Context, bktInfo *data.BucketInfo)
 		if err := json.Unmarshal([]byte(bktInfo.AttributeSettings), settings); err != nil {
 			return nil, fmt.Errorf("malformed data: %w", err)
 		}
-
-		n.cache.PutSettings(bktInfo, settings)
-		return settings, nil
-	}
-
-	id, err := n.searchBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketSettings)
-	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
-	}
-
-	if id.IsZero() {
-		n.cache.PutSettings(bktInfo, settings)
-		return settings, nil
-	}
-
-	settingsObj, err := n.objectGet(ctx, bktInfo, id)
-	if err != nil {
-		return nil, fmt.Errorf("get bucket settings object: %w", err)
-	}
-
-	// Took the latest version of the settings file. If you need any migrations,
-	// they should be done inside decodeBucketSettings.
-	settings, err = decodeBucketSettings(settingsObj)
-	if err != nil {
-		return nil, fmt.Errorf("decode bucket settings object: %w", err)
-	}
-
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		// Migrate bucket settings.
-		if err = n.storeAttribute(ctx, bktInfo.CID, attributeSettings, settings, boxData.Gate.SessionTokenV2); err != nil {
-			return nil, fmt.Errorf("store bucket settings object: %w", err)
-		}
-		if err = n.deleteBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketSettings); err != nil {
-			return nil, fmt.Errorf("delete obsolete bucket settings objects: %w", err)
-		}
 	}
 
 	n.cache.PutSettings(bktInfo, settings)
-	n.cache.DeleteBucket(bktInfo.Name)
-
 	return settings, nil
-}
-
-// decodeBucketSettings decodes and migrates (if required) buket settings file.
-func decodeBucketSettings(settingsObj *object.Object) (*data.BucketSettings, error) {
-	if settingsObj == nil {
-		return nil, fmt.Errorf("bucket settings object is nil")
-	}
-
-	var (
-		settingsVersion string
-		settings        = data.BucketSettings{Versioning: data.VersioningUnversioned}
-		versioning      string
-	)
-
-	for _, attr := range settingsObj.Attributes() {
-		switch attr.Key() {
-		case s3headers.BucketSettingsMetaVersion:
-			settingsVersion = attr.Value()
-		case s3headers.BucketSettingsVersioning:
-			versioning = attr.Value()
-		default:
-			continue
-		}
-	}
-
-	switch settingsVersion {
-	case data.BucketSettingsV1:
-		if err := json.Unmarshal(settingsObj.Payload(), &settings); err != nil {
-			return nil, fmt.Errorf("decode bucket settings: %w", err)
-		}
-	default:
-		var olc data.ObjectLockConfiguration
-		if err := olc.Decode(string(settingsObj.Payload())); err != nil {
-			return nil, fmt.Errorf("decode bucket settings: %w", err)
-		}
-
-		settings.LockConfiguration = &olc
-		settings.Versioning = versioning
-	}
-
-	return &settings, nil
 }
 
 // PutBucketSettings stores bucket settings. We should save the latest file version only.

--- a/api/layer/tagging.go
+++ b/api/layer/tagging.go
@@ -271,60 +271,30 @@ func (n *layer) DeleteObjectTagging(ctx context.Context, p *ObjectVersion) error
 }
 
 func (n *layer) GetBucketTagging(ctx context.Context, bktInfo *data.BucketInfo) (map[string]string, error) {
-	var (
-		err   error
-		owner = n.Owner(ctx)
-	)
+	var owner = n.Owner(ctx)
 
 	if tags := n.cache.GetTagging(owner, bucketTaggingCacheKey(bktInfo.CID)); tags != nil {
 		return tags, nil
 	}
 
-	var tags map[string]string
-	if bktInfo.AttributeTags != "" {
-		if err = json.Unmarshal([]byte(bktInfo.AttributeTags), &tags); err != nil {
-			return nil, fmt.Errorf("malformed data: %w", err)
-		}
-
-		if len(tags) > 0 {
-			n.cache.PutTagging(owner, bucketTaggingCacheKey(bktInfo.CID), tags)
-			return tags, nil
-		}
-	}
-
-	id, err := n.searchBucketMetaObjects(ctx, bktInfo, s3headers.TypeBucketTags)
-	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
-	}
-
-	if id.IsZero() {
+	if bktInfo.AttributeTags == "" {
 		return nil, s3errors.GetAPIError(s3errors.ErrBucketTaggingNotFound)
 	}
 
-	tags, err = n.getTagsByOID(ctx, bktInfo, id)
-	if err != nil {
-		return nil, err
+	var tags map[string]string
+	if err := json.Unmarshal([]byte(bktInfo.AttributeTags), &tags); err != nil {
+		return nil, fmt.Errorf("malformed data: %w", err)
 	}
 
 	if len(tags) == 0 {
+		// Empty tagset was set.
+		if item.Tags != nil {
+			return nil, nil
+		}
 		return nil, s3errors.GetAPIError(s3errors.ErrBucketTaggingNotFound)
 	}
 
-	boxData, err := GetBoxData(ctx)
-	if err == nil {
-		// Migrate bucket tags to contract.
-		if err = n.storeAttribute(ctx, bktInfo.CID, attributeTags, tags, boxData.Gate.SessionTokenV2); err != nil {
-			return nil, fmt.Errorf("bucket tags migration: %w", err)
-		}
-
-		if err = n.deleteBucketTagging(ctx, bktInfo); err != nil {
-			return nil, fmt.Errorf("couldn't delete bucket tags: %w", err)
-		}
-	}
-
 	n.cache.PutTagging(owner, bucketTaggingCacheKey(bktInfo.CID), tags)
-	n.cache.DeleteBucket(bktInfo.Name)
-
 	return tags, nil
 }
 
@@ -346,10 +316,6 @@ func (n *layer) PutBucketTagging(ctx context.Context, bktInfo *data.BucketInfo, 
 }
 
 func (n *layer) DeleteBucketTagging(ctx context.Context, bktInfo *data.BucketInfo) error {
-	if err := n.deleteBucketTagging(ctx, bktInfo); err != nil {
-		return fmt.Errorf("couldn't delete bucket tags: %w", err)
-	}
-
 	var sessionTokenV2 *session.Token
 	boxData, err := GetBoxData(ctx)
 	if err == nil {
@@ -358,38 +324,6 @@ func (n *layer) DeleteBucketTagging(ctx context.Context, bktInfo *data.BucketInf
 
 	if err = n.neoFS.RemoveContainerAttribute(ctx, bktInfo.CID, attributeTags, sessionTokenV2); err != nil {
 		return fmt.Errorf("couldn't remove bucket tags: %w", err)
-	}
-
-	n.cache.DeleteTagging(bucketTaggingCacheKey(bktInfo.CID))
-	n.cache.DeleteBucket(bktInfo.Name)
-
-	return nil
-}
-
-func (n *layer) deleteBucketTagging(ctx context.Context, bktInfo *data.BucketInfo) error {
-	fs := make(object.SearchFilters, 0, 1)
-	fs.AddFilter(s3headers.MetaType, s3headers.TypeBucketTags, object.MatchStringEqual)
-
-	var opts client.SearchObjectsOptions
-	attachTokenToParams(ctx, bktInfo.Owner, &opts)
-
-	res, err := n.neoFS.SearchObjectsV2(ctx, bktInfo.CID, fs, nil, opts)
-	if err != nil {
-		if errors.Is(err, apistatus.ErrObjectAccessDenied) {
-			return s3errors.GetAPIError(s3errors.ErrAccessDenied)
-		}
-
-		return fmt.Errorf("search object version: %w", err)
-	}
-
-	if len(res) == 0 {
-		return nil
-	}
-
-	for i := range res {
-		if err = n.objectDelete(ctx, bktInfo, res[i].ID); err != nil {
-			return fmt.Errorf("couldn't delete bucket tags object: %w", err)
-		}
 	}
 
 	n.cache.DeleteTagging(bucketTaggingCacheKey(bktInfo.CID))

--- a/api/layer/tagging.go
+++ b/api/layer/tagging.go
@@ -16,7 +16,6 @@ import (
 	"github.com/nspcc-dev/neofs-s3-gw/api/s3headers"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session/v2"
@@ -270,32 +269,16 @@ func (n *layer) DeleteObjectTagging(ctx context.Context, p *ObjectVersion) error
 	return n.PutObjectTagging(ctx, &putObjectTaggingParams)
 }
 
-func (n *layer) GetBucketTagging(ctx context.Context, bktInfo *data.BucketInfo) (map[string]string, error) {
-	var owner = n.Owner(ctx)
-
-	if tags := n.cache.GetTagging(owner, bucketTaggingCacheKey(bktInfo.CID)); tags != nil {
-		return tags, nil
-	}
-
-	if bktInfo.AttributeTags == "" {
-		return nil, s3errors.GetAPIError(s3errors.ErrBucketTaggingNotFound)
-	}
-
-	var tags map[string]string
-	if err := json.Unmarshal([]byte(bktInfo.AttributeTags), &tags); err != nil {
-		return nil, fmt.Errorf("malformed data: %w", err)
-	}
-
-	if len(tags) == 0 {
+func (n *layer) GetBucketTagging(_ context.Context, bktInfo *data.BucketInfo) (map[string]string, error) {
+	if len(bktInfo.Tags) == 0 {
 		// Empty tagset was set.
-		if item.Tags != nil {
+		if bktInfo.Tags != nil {
 			return nil, nil
 		}
 		return nil, s3errors.GetAPIError(s3errors.ErrBucketTaggingNotFound)
 	}
 
-	n.cache.PutTagging(owner, bucketTaggingCacheKey(bktInfo.CID), tags)
-	return tags, nil
+	return bktInfo.Tags, nil
 }
 
 func (n *layer) PutBucketTagging(ctx context.Context, bktInfo *data.BucketInfo, tagSet map[string]string) error {
@@ -309,7 +292,6 @@ func (n *layer) PutBucketTagging(ctx context.Context, bktInfo *data.BucketInfo, 
 		return fmt.Errorf("couldn't store bucket tags: %w", err)
 	}
 
-	n.cache.PutTagging(n.Owner(ctx), bucketTaggingCacheKey(bktInfo.CID), tagSet)
 	n.cache.DeleteBucket(bktInfo.Name)
 
 	return nil
@@ -326,7 +308,6 @@ func (n *layer) DeleteBucketTagging(ctx context.Context, bktInfo *data.BucketInf
 		return fmt.Errorf("couldn't remove bucket tags: %w", err)
 	}
 
-	n.cache.DeleteTagging(bucketTaggingCacheKey(bktInfo.CID))
 	n.cache.DeleteBucket(bktInfo.Name)
 
 	return nil
@@ -334,8 +315,4 @@ func (n *layer) DeleteBucketTagging(ctx context.Context, bktInfo *data.BucketInf
 
 func objectTaggingCacheKey(p *ObjectVersion) string {
 	return ".tagset." + p.BktInfo.CID.EncodeToString() + "." + p.ObjectName + "." + p.VersionID
-}
-
-func bucketTaggingCacheKey(cnrID cid.ID) string {
-	return ".tagset." + cnrID.EncodeToString()
 }

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -39,6 +39,20 @@ func (tc *testContext) putObject(content []byte) *data.ObjectInfo {
 	return extObjInfo.ObjectInfo
 }
 
+func (tc *testContext) putBucketSettings(settings *data.BucketSettings) {
+	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
+		BktInfo:  tc.bktInfo,
+		Settings: settings,
+	})
+	require.NoError(tc.t, err)
+
+	cnr, err := tc.testNeoFS.Container(tc.ctx, tc.bktInfo.CID)
+	require.NoError(tc.t, err)
+
+	tc.bktInfo.AttributeSettings = cnr.Attribute(attributeSettings)
+	require.NoError(tc.t, tc.bktInfo.ParseSettings())
+}
+
 func (tc *testContext) getObject(objectName, versionID string, needError bool) (*data.ObjectInfo, []byte) {
 	objInfo, err := tc.layer.GetObjectInfo(tc.ctx, &HeadObjectParams{
 		BktInfo:   tc.bktInfo,
@@ -181,9 +195,11 @@ func prepareContext(t *testing.T, cachesConfig ...*CachesConfig) *testContext {
 		ctx:   ctx,
 		layer: NewLayer(logger, tp, layerCfg),
 		bktInfo: &data.BucketInfo{
-			Name:  bktName,
-			Owner: owner,
-			CID:   bktID,
+			Name:          bktName,
+			Owner:         owner,
+			CID:           bktID,
+			Settings:      &data.BucketSettings{Versioning: data.VersioningUnversioned},
+			Notifications: &data.NotificationConfiguration{},
 		},
 		obj:       "obj1",
 		t:         t,
@@ -193,11 +209,7 @@ func prepareContext(t *testing.T, cachesConfig ...*CachesConfig) *testContext {
 
 func TestSimpleVersioning(t *testing.T) {
 	tc := prepareContext(t)
-	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
-		BktInfo:  tc.bktInfo,
-		Settings: &data.BucketSettings{Versioning: data.VersioningEnabled},
-	})
-	require.NoError(t, err)
+	tc.putBucketSettings(&data.BucketSettings{Versioning: data.VersioningEnabled})
 
 	obj1Content1 := []byte("content obj1 v1")
 	obj1v1 := tc.putObject(obj1Content1)
@@ -233,11 +245,7 @@ func TestSimpleNoVersioning(t *testing.T) {
 func TestVersioningDeleteObject(t *testing.T) {
 	tc := prepareContext(t)
 	settings := &data.BucketSettings{Versioning: data.VersioningEnabled}
-	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
-		BktInfo:  tc.bktInfo,
-		Settings: settings,
-	})
-	require.NoError(t, err)
+	tc.putBucketSettings(settings)
 
 	tc.putObject([]byte("content obj1 v1"))
 	tc.putObject([]byte("content obj1 v2"))
@@ -255,11 +263,7 @@ func TestGetUnversioned(t *testing.T) {
 	objInfo := tc.putObject(objContent)
 
 	settings := &data.BucketSettings{Versioning: data.VersioningUnversioned}
-	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
-		BktInfo:  tc.bktInfo,
-		Settings: settings,
-	})
-	require.NoError(t, err)
+	tc.putBucketSettings(settings)
 
 	resInfo, buffer := tc.getObject(tc.obj, data.UnversionedObjectVersionID, false)
 	require.Equal(t, objContent, buffer)
@@ -269,11 +273,7 @@ func TestGetUnversioned(t *testing.T) {
 func TestVersioningDeleteSpecificObjectVersion(t *testing.T) {
 	tc := prepareContext(t)
 	settings := &data.BucketSettings{Versioning: data.VersioningEnabled}
-	err := tc.layer.PutBucketSettings(tc.ctx, &PutSettingsParams{
-		BktInfo:  tc.bktInfo,
-		Settings: settings,
-	})
-	require.NoError(t, err)
+	tc.putBucketSettings(settings)
 
 	tc.putObject([]byte("content obj1 v1"))
 	objV2Info := tc.putObject([]byte("content obj1 v2"))

--- a/api/layer/versioning_test.go
+++ b/api/layer/versioning_test.go
@@ -307,10 +307,7 @@ func TestNoVersioningDeleteObject(t *testing.T) {
 	tc.putObject([]byte("content obj1 v1"))
 	tc.putObject([]byte("content obj1 v2"))
 
-	settings, err := tc.layer.GetBucketSettings(tc.ctx, tc.bktInfo)
-	require.NoError(t, err)
-
-	tc.deleteObject(tc.obj, "", settings)
+	tc.deleteObject(tc.obj, "", tc.bktInfo.Settings)
 	tc.getObject(tc.obj, "", true)
 	tc.checkListObjects()
 }

--- a/api/s3headers/headers.go
+++ b/api/s3headers/headers.go
@@ -29,23 +29,12 @@ const (
 	// Result: S3-MetaType.
 	MetaType = attributePrefix + "MetaType"
 
-	TypeTags              = "tags"
-	TypeBucketTags        = "bucketTags"
-	TypeBucketNotifConfig = "bucketNotifConf"
-	TypeBucketCORS        = "bucketCORS"
-	TypeBucketSettings    = "bucketSettings"
-	TypeMultipartInfo     = "multipartInfo"
-	TypeMultipartPart     = "multipartPart"
+	TypeTags          = "tags"
+	TypeMultipartInfo = "multipartInfo"
+	TypeMultipartPart = "multipartPart"
 )
 
 const (
-	bucketSettingsPrefix = attributePrefix + "BucketSettings-"
-
-	// BucketSettingsVersioning contains versioning setting for bucket.
-	BucketSettingsVersioning = bucketSettingsPrefix + "Versioning"
-	// BucketSettingsMetaVersion contains version of bucket settings file.
-	BucketSettingsMetaVersion = bucketSettingsPrefix + "MetaVersion"
-
 	AttributeObjectNonce = "__NEOFS__NONCE"
 
 	// Result: S3-Lock-Meta.

--- a/docs/attribute_mapping.md
+++ b/docs/attribute_mapping.md
@@ -173,14 +173,6 @@ Contains the original object's attributes.
 
 Contains the final creation timestamp of the object.
 
-### `S3-BucketSettings-Versioning`
-
-Indicates whether bucket versioning is enabled.
-
-### `S3-BucketSettings-MetaVersion`
-
-Specifies the version of the bucket settings object's file structure
-
 ### `__NEOFS__ASSOCIATE`
 
 Used for auxiliary objects like tags and locks, indicates which original object
@@ -222,14 +214,22 @@ Describes special metadata types used for S3 features.
 **Possible values:**
 
 - `tags` – Stores object tags
-- `bucketTags` – Stores bucket tags
-- `bucketNotifConf` – Stores bucket notification configuration
-- `bucketCORS` – Stores bucket CORS configuration
-- `bucketSettings` – Stores bucket settings
 - `multipartInfo` – Stores multipart upload metadata
 - `multipartPart` – Stores information about an individual part
 
 ---
+
+## Bucket-Level Configuration
+
+Bucket settings, CORS, tags and notification configuration are kept as attributes
+on the bucket's container:
+
+| Attribute          | Contents                                 |
+|--------------------|------------------------------------------|
+| `S3_SETTINGS`      | Bucket settings as JSON.                 |
+| `CORS`             | CORS configuration as JSON.              |
+| `S3_TAGS`          | Bucket tags as JSON (map[string]string). |
+| `S3_NOTIFICATIONS` | Notification configuration as JSON.      |
 
 ## Special Meta Objects
 
@@ -263,58 +263,3 @@ the original object's attributes.
 
 - `S3-MetaType: tags`
 - `__NEOFS__ASSOCIATE`
-
-### Bucket Tags Object
-
-Stores tag data for a bucket. Contents is a JSON object with string keys and
-values repsenting tags.
-
-**Attributes:**
-
-- `S3-MetaType: bucketTags`
-
-### Bucket Notifications Object
-
-Stores bucket notification configuration.
-
-**Attributes:**
-
-- `S3-MetaType: bucketNotifConf`
-
-The object payload contains the configuration data.
-
-[Format](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration.html)
-> Note `QueueConfigurations` only supported.
-
-### Bucket CORS Object
-
-Stores bucket CORS configuration.
-
-**Attributes:**
-
-- `S3-MetaType: bucketCORS`
-
-The object payload contains the configuration data in XML format.
-[Format](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html)
-
-### Bucket Settings Object
-
-Stores settings configuration for a bucket.
-
-**Attributes:**
-
-- `S3-MetaType: bucketSettings`
-- `S3-BucketSettings-Versioning`
-  Deprecated, replaced by meta version.
-- `S3-BucketSettings-MetaVersion`
-  Stores settings version.
-
-The object payload contains settings data in JSON format. For version 1 it's
-an object with the following fields:
- * "versioning", corresponding to bucket versioning settings
-   (Unversioned/Enabled/Suspended)
- * "lock_configuration" which is an object with "ObjectLockEnabled" and "Rule"
-   members corresponding to XML parameters of lock configuration in S3 API
- * "bucket_owner" which is a number representing object ownership and ACL
-   settings (0 for owner enforced, 1 for owner preferred, 2 for owner
-   preferred and restricted and 3 for object writer owner)


### PR DESCRIPTION
Closes #1265.

There is one issue with `[test_100_continue](https://github.com/nspcc-dev/s3-tests/blob/eba16d41ce7da553897531a4bd6edae79463abbe/s3tests_boto3/functional/test_s3.py#L8151)` in `s3-tests`.

It expects 403 on the first step. Previously, we had a search for settings in a private container and got 403. Now we don't have a search, and the test fails on [this](https://github.com/nspcc-dev/s3-tests/blob/eba16d41ce7da553897531a4bd6edae79463abbe/s3tests_boto3/functional/test_s3.py#L8164) check.

I consider, in this case, removing two strings with a 403 check from the test is a good decision. In another case, make an empty search to get the correct error - sounds strange and affects performance