### PR TITLE
neofs: disable checksum verification for now

### DIFF
--- a/internal/neofs/neofs.go
+++ b/internal/neofs/neofs.go
@@ -553,6 +553,7 @@ func (x *NeoFS) ReadObject(ctx context.Context, prm layer.PrmObjectRead) (*layer
 	}
 
 	var prmGet client.PrmObjectGet
+	prmGet.SkipChecksumVerification()
 
 	if prm.SessionTokenV2 != nil {
 		prmGet.WithinSessionV2(*prm.SessionTokenV2)


### PR DESCRIPTION
It can affect performance and it does burn some CPU cycles. Even though theoretically a single core can make about 2 GB/s and this shouldn't be noticeably various client tests can show significant difference with this enabled or not.