### PR TITLE
go.mod: upgrade SDK to RC20+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nats-io/nats.go v1.49.0
 	github.com/nspcc-dev/neo-go v0.118.0
 	github.com/nspcc-dev/neofs-contract v0.26.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.20.0.20260701132011-c8072a564b1f
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/nspcc-dev/neo-go v0.118.0 h1:3zTSBbAtT4qosubVzLLOWzEky2GLZ/LUzf9nZTu5
 github.com/nspcc-dev/neo-go v0.118.0/go.mod h1:6f+QLr3wg4p1xoVLxy4tyUwYOnx4mL5ashd+jCPA3iY=
 github.com/nspcc-dev/neofs-contract v0.26.1 h1:7Ii7Q4L3au408LOsIWKiSgfnT1g8G9jo3W7381d41T8=
 github.com/nspcc-dev/neofs-contract v0.26.1/go.mod h1:pevVF9OWdEN5bweKxOu6ryZv9muCEtS1ppzYM4RfBIo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19 h1:GHMk5bO+gL2uh7tY8r1FTyjtZ+izHTF2WbiNO4pkelo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19/go.mod h1:KtAAolqjEdTNZ8T57FvpWsE/i9/Bpj6wuRPeUs/U85I=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.20.0.20260701132011-c8072a564b1f h1:ZiOysFfMkLBtoGKi+oMA8aptoIWHape8njzhLvYlMr4=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.20.0.20260701132011-c8072a564b1f/go.mod h1:KtAAolqjEdTNZ8T57FvpWsE/i9/Bpj6wuRPeUs/U85I=
 github.com/nspcc-dev/rfc6979 v0.2.4 h1:NBgsdCjhLpEPJZqmC9rciMZDcSY297po2smeaRjw57k=
 github.com/nspcc-dev/rfc6979 v0.2.4/go.mod h1:86ylDw6Kss+P6v4QAJqo1Sp3mC0/Zr9G97xSjQ9TuFg=
 github.com/nspcc-dev/tzhash v1.8.4 h1:lvuPGWsqEo9dVEvo/kdNLKv/Cy0yxRs9z5hJp8VcBuo=


### PR DESCRIPTION
Fetch https://github.com/nspcc-dev/neofs-sdk-go/pull/818.